### PR TITLE
Refactor onDetachedFromEngine method

### DIFF
--- a/android/src/main/java/org/opentraa/pip/PipPlugin.java
+++ b/android/src/main/java/org/opentraa/pip/PipPlugin.java
@@ -107,13 +107,18 @@ public class PipPlugin
     }
   }
 
-  @Override
-  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-    channel.setMethodCallHandler(null);
-    if(pipController!=null){
-      pipController.dispose();
+@Override
+public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    if (channel != null) {
+        channel.setMethodCallHandler(null);
+        channel = null;
     }
-  }
+
+    if (pipController != null) {
+        pipController.dispose();
+        pipController = null;
+    }
+}
 
   private void initPipController(@NonNull ActivityPluginBinding binding) {
     if (pipController == null) {


### PR DESCRIPTION
Fixes a crash in onDetachedFromEngine() by safely checking nullable plugin resources before cleanup.

Changes
Added null checks for channel and pipController
Set both references to null after cleanup
Why

pipController can be null when the plugin is detached from a secondary Flutter engine, causing:

NullPointerException: pipController.dispose()
Result

Prevents crashes during Flutter engine shutdown, especially when used with foreground/background services.