### PR TITLE
fix: stabilize native state event protocol

### DIFF
--- a/android/src/main/java/org/opentraa/pip/PipPlugin.java
+++ b/android/src/main/java/org/opentraa/pip/PipPlugin.java
@@ -26,6 +26,19 @@ public class PipPlugin
   /// The controller for the PiP feature
   private PipController pipController;
 
+  private String toStateCode(PipController.PipState state) {
+    switch (state) {
+    case Started:
+      return "started";
+    case Stopped:
+      return "stopped";
+    case Failed:
+      return "failed";
+    default:
+      return "unknown";
+    }
+  }
+
   @Override
   public void
   onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
@@ -130,7 +143,7 @@ public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
               // put state into a json object
               channel.invokeMethod("stateChanged",
                                    new HashMap<String, Object>() {
-                                     { put("state", state.getValue()); }
+                                     { put("state", toStateCode(state)); }
                                    });
             }
           });

--- a/ios/pip/Sources/pip/PipPlugin.m
+++ b/ios/pip/Sources/pip/PipPlugin.m
@@ -94,10 +94,24 @@
 }
 
 - (void)pipStateChanged:(PipState)state error:(NSString *)error {
-  NSDictionary *arguments = [[NSDictionary alloc]
-      initWithObjectsAndKeys:[NSNumber numberWithLong:(long)state], @"state",
-                             error, @"error", nil];
+  NSMutableDictionary *arguments =
+      [@{@"state" : [self stateCode:state]} mutableCopy];
+  if (error != nil) {
+    arguments[@"error"] = error;
+  }
   [self.channel invokeMethod:@"stateChanged" arguments:arguments];
+}
+
+- (NSString *)stateCode:(PipState)state {
+  switch (state) {
+  case PipStateStarted:
+    return @"started";
+  case PipStateStopped:
+    return @"stopped";
+  case PipStateFailed:
+    return @"failed";
+  }
+  return @"unknown";
 }
 
 @end

--- a/lib/pip_method_channel.dart
+++ b/lib/pip_method_channel.dart
@@ -18,21 +18,29 @@ class MethodChannelPip extends PipPlatform {
   }
 
   Future<void> _handleMethod(MethodCall call) async {
-    try {
-      if (call.method == 'stateChanged') {
-        final jsonMap = Map<String, dynamic>.from(call.arguments as Map);
-        final state = jsonMap['state'] as int;
-        final error = jsonMap['error'] as String?;
-        _stateChangedObserver?.onPipStateChanged(PipState.values[state], error);
-      }
-    } catch (e) {
-      assert(false, 'stateChanged error: $e');
+    if (call.method != 'stateChanged') {
+      return;
     }
+
+    final arguments = call.arguments;
+    if (arguments is! Map) {
+      return;
+    }
+
+    final jsonMap = Map<Object?, Object?>.from(arguments);
+    final state = PipState.fromNative(jsonMap['state']);
+    final error = jsonMap['error'];
+    if (state == null || (error != null && error is! String)) {
+      return;
+    }
+
+    _stateChangedObserver?.onPipStateChanged(state, error as String?);
   }
 
   @override
   Future<void> registerStateChangedObserver(
-      PipStateChangedObserver observer) async {
+    PipStateChangedObserver observer,
+  ) async {
     _stateChangedObserver = observer;
   }
 
@@ -49,8 +57,10 @@ class MethodChannelPip extends PipPlatform {
 
   @override
   Future<bool> isAutoEnterSupported() async {
-    final result =
-        await methodChannel.invokeMethod<bool>('isAutoEnterSupported', null);
+    final result = await methodChannel.invokeMethod<bool>(
+      'isAutoEnterSupported',
+      null,
+    );
     return result ?? false;
   }
 

--- a/lib/pip_platform_interface.dart
+++ b/lib/pip_platform_interface.dart
@@ -111,9 +111,13 @@ class PipOptions {
       writePropertyIfNotNull('sourceRectHintBottom', sourceRectHintBottom);
       writePropertyIfNotNull('seamlessResizeEnabled', seamlessResizeEnabled);
       writePropertyIfNotNull(
-          'useExternalStateMonitor', useExternalStateMonitor);
+        'useExternalStateMonitor',
+        useExternalStateMonitor,
+      );
       writePropertyIfNotNull(
-          'externalStateMonitorInterval', externalStateMonitorInterval);
+        'externalStateMonitorInterval',
+        externalStateMonitorInterval,
+      );
     }
 
     // only for ios
@@ -137,14 +141,48 @@ enum PipState {
   pipStateStopped,
 
   /// The Picture in Picture is failed.
-  pipStateFailed,
+  pipStateFailed;
+
+  /// Stable native wire protocol code for this state.
+  String get code {
+    switch (this) {
+      case PipState.pipStateStarted:
+        return 'started';
+      case PipState.pipStateStopped:
+        return 'stopped';
+      case PipState.pipStateFailed:
+        return 'failed';
+    }
+  }
+
+  /// Parses native wire protocol values into [PipState].
+  ///
+  /// String values are the stable protocol. Integer values are accepted for
+  /// backward compatibility with older native implementations.
+  static PipState? fromNative(Object? value) {
+    if (value is String) {
+      switch (value) {
+        case 'started':
+          return PipState.pipStateStarted;
+        case 'stopped':
+          return PipState.pipStateStopped;
+        case 'failed':
+          return PipState.pipStateFailed;
+      }
+      return null;
+    }
+
+    if (value is int && value >= 0 && value < PipState.values.length) {
+      return PipState.values[value];
+    }
+
+    return null;
+  }
 }
 
 class PipStateChangedObserver {
   /// The observer of the Picture in Picture state changed.
-  const PipStateChangedObserver({
-    required this.onPipStateChanged,
-  });
+  const PipStateChangedObserver({required this.onPipStateChanged});
 
   /// The callback of the Picture in Picture state changed.
   final void Function(PipState state, String? error) onPipStateChanged;
@@ -175,15 +213,18 @@ abstract class PipPlatform extends PlatformInterface {
   ///
   /// [observer] The Picture in Picture state change observer.
   Future<void> registerStateChangedObserver(
-      PipStateChangedObserver observer) async {
+    PipStateChangedObserver observer,
+  ) async {
     throw UnimplementedError(
-        'registerStateChangedObserver() has not been implemented.');
+      'registerStateChangedObserver() has not been implemented.',
+    );
   }
 
   /// Unregisters a Picture in Picture state change observer.
   Future<void> unregisterStateChangedObserver() async {
     throw UnimplementedError(
-        'unregisterStateChangedObserver() has not been implemented.');
+      'unregisterStateChangedObserver() has not been implemented.',
+    );
   }
 
   /// Check if Picture in Picture is supported.
@@ -200,7 +241,8 @@ abstract class PipPlatform extends PlatformInterface {
   /// Whether Picture in Picture can auto enter.
   Future<bool> isAutoEnterSupported() async {
     throw UnimplementedError(
-        'isAutoEnterSupported() has not been implemented.');
+      'isAutoEnterSupported() has not been implemented.',
+    );
   }
 
   /// Check if Picture in Picture is actived.

--- a/test/pip_method_channel_test.dart
+++ b/test/pip_method_channel_test.dart
@@ -17,24 +17,24 @@ void main() {
     methodCalls = <MethodCall>[];
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-      methodCalls.add(methodCall);
-      switch (methodCall.method) {
-        case 'isSupported':
-        case 'isAutoEnterSupported':
-        case 'setup':
-        case 'start':
-          return true;
-        case 'isActived':
-          return false;
-        case 'getPipView':
-          return 123;
-        case 'stop':
-        case 'dispose':
-          return null;
-        default:
-          throw PlatformException(code: 'unimplemented');
-      }
-    });
+          methodCalls.add(methodCall);
+          switch (methodCall.method) {
+            case 'isSupported':
+            case 'isAutoEnterSupported':
+            case 'setup':
+            case 'start':
+              return true;
+            case 'isActived':
+              return false;
+            case 'getPipView':
+              return 123;
+            case 'stop':
+            case 'dispose':
+              return null;
+            default:
+              throw PlatformException(code: 'unimplemented');
+          }
+        });
   });
 
   tearDown(() {
@@ -46,24 +46,23 @@ void main() {
     expect(await platform.isSupported(), isTrue);
     expect(await platform.isAutoEnterSupported(), isTrue);
     expect(await platform.isActived(), isFalse);
-    expect(await platform.setup(const PipOptions(autoEnterEnabled: true)),
-        isTrue);
+    expect(
+      await platform.setup(const PipOptions(autoEnterEnabled: true)),
+      isTrue,
+    );
     expect(await platform.start(), isTrue);
     await platform.stop();
     await platform.dispose();
 
-    expect(
-      methodCalls.map((call) => call.method),
-      <String>[
-        'isSupported',
-        'isAutoEnterSupported',
-        'isActived',
-        'setup',
-        'start',
-        'stop',
-        'dispose',
-      ],
-    );
+    expect(methodCalls.map((call) => call.method), <String>[
+      'isSupported',
+      'isAutoEnterSupported',
+      'isActived',
+      'setup',
+      'start',
+      'stop',
+      'dispose',
+    ]);
   });
 
   test('returns a native PiP view pointer on iOS only', () async {
@@ -77,26 +76,27 @@ void main() {
   });
 
   test('serializes setup options for the active platform', () async {
-    await platform.setup(const PipOptions(
-      autoEnterEnabled: true,
-      aspectRatioX: 16,
-      aspectRatioY: 9,
-      sourceRectHintLeft: 1,
-      sourceRectHintTop: 2,
-      sourceRectHintRight: 3,
-      sourceRectHintBottom: 4,
-      seamlessResizeEnabled: true,
-      useExternalStateMonitor: true,
-      externalStateMonitorInterval: 100,
-      sourceContentView: 10,
-      contentView: 11,
-      preferredContentWidth: 200,
-      preferredContentHeight: 100,
-      controlStyle: 2,
-    ));
+    await platform.setup(
+      const PipOptions(
+        autoEnterEnabled: true,
+        aspectRatioX: 16,
+        aspectRatioY: 9,
+        sourceRectHintLeft: 1,
+        sourceRectHintTop: 2,
+        sourceRectHintRight: 3,
+        sourceRectHintBottom: 4,
+        seamlessResizeEnabled: true,
+        useExternalStateMonitor: true,
+        externalStateMonitorInterval: 100,
+        sourceContentView: 10,
+        contentView: 11,
+        preferredContentWidth: 200,
+        preferredContentHeight: 100,
+        controlStyle: 2,
+      ),
+    );
 
-    final setupCall =
-        methodCalls.singleWhere((call) => call.method == 'setup');
+    final setupCall = methodCalls.singleWhere((call) => call.method == 'setup');
     final arguments = Map<String, Object?>.from(setupCall.arguments as Map);
 
     expect(arguments['autoEnterEnabled'], isTrue);
@@ -135,17 +135,204 @@ void main() {
 
     await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .handlePlatformMessage(
-      'pip',
-      channel.codec.encodeMethodCall(
-        const MethodCall('stateChanged', <String, Object?>{
-          'state': 2,
-          'error': 'Pip is not possible',
-        }),
-      ),
-      (_) {},
-    );
+          'pip',
+          channel.codec.encodeMethodCall(
+            const MethodCall('stateChanged', <String, Object?>{
+              'state': 2,
+              'error': 'Pip is not possible',
+            }),
+          ),
+          (_) {},
+        );
 
     expect(receivedState, PipState.pipStateFailed);
     expect(receivedError, 'Pip is not possible');
   });
+
+  test('accepts stable native state code strings', () async {
+    final expectedStates = <String, PipState>{
+      'started': PipState.pipStateStarted,
+      'stopped': PipState.pipStateStopped,
+      'failed': PipState.pipStateFailed,
+    };
+
+    for (final entry in expectedStates.entries) {
+      PipState? receivedState;
+      await platform.registerStateChangedObserver(
+        PipStateChangedObserver(
+          onPipStateChanged: (state, _) {
+            receivedState = state;
+          },
+        ),
+      );
+
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+            'pip',
+            channel.codec.encodeMethodCall(
+              MethodCall('stateChanged', <String, Object?>{'state': entry.key}),
+            ),
+            (_) {},
+          );
+
+      expect(receivedState, entry.value);
+    }
+  });
+
+  test(
+    'ignores unknown native state code strings without notifying observers',
+    () async {
+      var callbackCount = 0;
+      await platform.registerStateChangedObserver(
+        PipStateChangedObserver(
+          onPipStateChanged: (_, __) {
+            callbackCount += 1;
+          },
+        ),
+      );
+
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+            'pip',
+            channel.codec.encodeMethodCall(
+              const MethodCall('stateChanged', <String, Object?>{
+                'state': 'unknown',
+              }),
+            ),
+            (_) {},
+          );
+
+      expect(callbackCount, 0);
+    },
+  );
+
+  test(
+    'ignores invalid native state payloads without notifying observers',
+    () async {
+      var callbackCount = 0;
+      await platform.registerStateChangedObserver(
+        PipStateChangedObserver(
+          onPipStateChanged: (_, __) {
+            callbackCount += 1;
+          },
+        ),
+      );
+
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+            'pip',
+            channel.codec.encodeMethodCall(
+              const MethodCall('stateChanged', <String, Object?>{
+                'state': 'not-a-valid-state',
+                'error': 123,
+              }),
+            ),
+            (_) {},
+          );
+
+      expect(callbackCount, 0);
+    },
+  );
+
+  test(
+    'ignores non-map native state payloads without notifying observers',
+    () async {
+      var callbackCount = 0;
+      await platform.registerStateChangedObserver(
+        PipStateChangedObserver(
+          onPipStateChanged: (_, __) {
+            callbackCount += 1;
+          },
+        ),
+      );
+
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+            'pip',
+            channel.codec.encodeMethodCall(
+              const MethodCall('stateChanged', 'started'),
+            ),
+            (_) {},
+          );
+
+      expect(callbackCount, 0);
+    },
+  );
+
+  test('ignores unknown native methods without notifying observers', () async {
+    var callbackCount = 0;
+    await platform.registerStateChangedObserver(
+      PipStateChangedObserver(
+        onPipStateChanged: (_, __) {
+          callbackCount += 1;
+        },
+      ),
+    );
+
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+          'pip',
+          channel.codec.encodeMethodCall(
+            const MethodCall('unknownMethod', <String, Object?>{
+              'state': 'started',
+            }),
+          ),
+          (_) {},
+        );
+
+    expect(callbackCount, 0);
+  });
+
+  test(
+    'ignores non-string native state errors without notifying observers',
+    () async {
+      var callbackCount = 0;
+      await platform.registerStateChangedObserver(
+        PipStateChangedObserver(
+          onPipStateChanged: (_, __) {
+            callbackCount += 1;
+          },
+        ),
+      );
+
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+            'pip',
+            channel.codec.encodeMethodCall(
+              const MethodCall('stateChanged', <String, Object?>{
+                'state': 'failed',
+                'error': 123,
+              }),
+            ),
+            (_) {},
+          );
+
+      expect(callbackCount, 0);
+    },
+  );
+
+  test(
+    'keeps backward compatibility with legacy native state indexes',
+    () async {
+      PipState? receivedState;
+      await platform.registerStateChangedObserver(
+        PipStateChangedObserver(
+          onPipStateChanged: (state, _) {
+            receivedState = state;
+          },
+        ),
+      );
+
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+            'pip',
+            channel.codec.encodeMethodCall(
+              const MethodCall('stateChanged', <String, Object?>{'state': 1}),
+            ),
+            (_) {},
+          );
+
+      expect(receivedState, PipState.pipStateStopped);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

- send stable string PiP state codes from Android and iOS native callbacks
- parse native state events defensively in Dart while preserving legacy int payload compatibility
- add MethodChannel tests for valid string states and malformed native payloads

## Testing

- [x] `flutter test test/pip_method_channel_test.dart`
- [x] `flutter test`
- [x] `flutter analyze`
- [x] `./scripts/check_spm.sh`
- [x] `./scripts/check.sh`

## Review

- [x] Spec compliance subagent review
- [x] Code quality subagent review