### PR TITLE
fix: validate pip setup options

### DIFF
--- a/lib/pip_platform_interface.dart
+++ b/lib/pip_platform_interface.dart
@@ -91,6 +91,9 @@ class PipOptions {
 
   /// Convert the options to a dictionary.
   Map<String, dynamic> toDictionary() {
+    final targetPlatform = defaultTargetPlatform;
+    _validate(targetPlatform);
+
     final val = <String, dynamic>{};
 
     void writePropertyIfNotNull(String key, dynamic value) {
@@ -102,7 +105,7 @@ class PipOptions {
     writePropertyIfNotNull('autoEnterEnabled', autoEnterEnabled);
 
     // only for android
-    if (defaultTargetPlatform == TargetPlatform.android) {
+    if (targetPlatform == TargetPlatform.android) {
       writePropertyIfNotNull('aspectRatioX', aspectRatioX);
       writePropertyIfNotNull('aspectRatioY', aspectRatioY);
       writePropertyIfNotNull('sourceRectHintLeft', sourceRectHintLeft);
@@ -121,7 +124,7 @@ class PipOptions {
     }
 
     // only for ios
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
+    if (targetPlatform == TargetPlatform.iOS) {
       writePropertyIfNotNull('sourceContentView', sourceContentView);
       writePropertyIfNotNull('contentView', contentView);
       writePropertyIfNotNull('preferredContentWidth', preferredContentWidth);
@@ -129,6 +132,83 @@ class PipOptions {
       writePropertyIfNotNull('controlStyle', controlStyle);
     }
     return val;
+  }
+
+  void _validate(TargetPlatform targetPlatform) {
+    if (targetPlatform == TargetPlatform.android) {
+      _validateAndroidOptions();
+    }
+    if (targetPlatform == TargetPlatform.iOS) {
+      _validateIosOptions();
+    }
+  }
+
+  void _validateAndroidOptions() {
+    final hasAspectRatioX = aspectRatioX != null;
+    final hasAspectRatioY = aspectRatioY != null;
+    if (hasAspectRatioX != hasAspectRatioY) {
+      throw ArgumentError(
+        'aspectRatioX and aspectRatioY must be provided together.',
+      );
+    }
+    if (aspectRatioX != null && aspectRatioX! <= 0) {
+      throw ArgumentError.value(aspectRatioX, 'aspectRatioX');
+    }
+    if (aspectRatioY != null && aspectRatioY! <= 0) {
+      throw ArgumentError.value(aspectRatioY, 'aspectRatioY');
+    }
+
+    final rectValues = <int?>[
+      sourceRectHintLeft,
+      sourceRectHintTop,
+      sourceRectHintRight,
+      sourceRectHintBottom,
+    ];
+    final rectValueCount = rectValues.where((value) => value != null).length;
+    if (rectValueCount != 0 && rectValueCount != rectValues.length) {
+      throw ArgumentError(
+        'All sourceRectHint values must be provided together.',
+      );
+    }
+    final isEmptySourceRectHint =
+        sourceRectHintLeft == 0 &&
+        sourceRectHintTop == 0 &&
+        sourceRectHintRight == 0 &&
+        sourceRectHintBottom == 0;
+    if (sourceRectHintLeft != null &&
+        !isEmptySourceRectHint &&
+        sourceRectHintRight! <= sourceRectHintLeft!) {
+      throw ArgumentError('sourceRectHintRight must be greater than left.');
+    }
+    if (sourceRectHintTop != null &&
+        !isEmptySourceRectHint &&
+        sourceRectHintBottom! <= sourceRectHintTop!) {
+      throw ArgumentError('sourceRectHintBottom must be greater than top.');
+    }
+
+    if (externalStateMonitorInterval != null &&
+        externalStateMonitorInterval! <= 0) {
+      throw ArgumentError.value(
+        externalStateMonitorInterval,
+        'externalStateMonitorInterval',
+      );
+    }
+  }
+
+  void _validateIosOptions() {
+    if (preferredContentWidth != null && preferredContentWidth! <= 0) {
+      throw ArgumentError.value(preferredContentWidth, 'preferredContentWidth');
+    }
+    if (preferredContentHeight != null && preferredContentHeight! <= 0) {
+      throw ArgumentError.value(
+        preferredContentHeight,
+        'preferredContentHeight',
+      );
+    }
+
+    if (controlStyle != null && (controlStyle! < 0 || controlStyle! > 3)) {
+      throw ArgumentError.value(controlStyle, 'controlStyle');
+    }
   }
 }
 

--- a/lib/pip_platform_interface.dart
+++ b/lib/pip_platform_interface.dart
@@ -196,6 +196,13 @@ class PipOptions {
   }
 
   void _validateIosOptions() {
+    final hasPreferredContentWidth = preferredContentWidth != null;
+    final hasPreferredContentHeight = preferredContentHeight != null;
+    if (hasPreferredContentWidth != hasPreferredContentHeight) {
+      throw ArgumentError(
+        'preferredContentWidth and preferredContentHeight must be provided together.',
+      );
+    }
     if (preferredContentWidth != null && preferredContentWidth! <= 0) {
       throw ArgumentError.value(preferredContentWidth, 'preferredContentWidth');
     }

--- a/test/pip_method_channel_test.dart
+++ b/test/pip_method_channel_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pip/pip_platform_interface.dart';
@@ -40,6 +41,7 @@ void main() {
   tearDown(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, null);
+    debugDefaultTargetPlatformOverride = null;
   });
 
   test('forwards platform method calls to the native channel', () async {
@@ -119,6 +121,131 @@ void main() {
       expect(arguments['controlStyle'], 2);
       expect(arguments.containsKey('aspectRatioX'), isFalse);
     }
+  });
+
+  test('rejects incomplete Android aspect ratio options', () {
+    withTargetPlatform(TargetPlatform.android, () {
+      expect(
+        () => const PipOptions(aspectRatioX: 16).toDictionary(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  test('rejects invalid Android aspect ratio options', () {
+    withTargetPlatform(TargetPlatform.android, () {
+      expect(
+        () =>
+            const PipOptions(aspectRatioX: 16, aspectRatioY: 0).toDictionary(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  test('rejects incomplete Android source rect hint options', () {
+    withTargetPlatform(TargetPlatform.android, () {
+      expect(
+        () => const PipOptions(
+          sourceRectHintLeft: 1,
+          sourceRectHintTop: 2,
+          sourceRectHintRight: 3,
+        ).toDictionary(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  test('rejects invalid Android source rect hint bounds', () {
+    withTargetPlatform(TargetPlatform.android, () {
+      expect(
+        () => const PipOptions(
+          sourceRectHintLeft: 3,
+          sourceRectHintTop: 2,
+          sourceRectHintRight: 1,
+          sourceRectHintBottom: 4,
+        ).toDictionary(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => const PipOptions(
+          sourceRectHintLeft: 1,
+          sourceRectHintTop: 4,
+          sourceRectHintRight: 3,
+          sourceRectHintBottom: 2,
+        ).toDictionary(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  test('allows empty Android source rect hint bounds', () {
+    withTargetPlatform(TargetPlatform.android, () {
+      expect(
+        const PipOptions(
+          sourceRectHintLeft: 0,
+          sourceRectHintTop: 0,
+          sourceRectHintRight: 0,
+          sourceRectHintBottom: 0,
+        ).toDictionary(),
+        allOf(
+          containsPair('sourceRectHintLeft', 0),
+          containsPair('sourceRectHintTop', 0),
+          containsPair('sourceRectHintRight', 0),
+          containsPair('sourceRectHintBottom', 0),
+        ),
+      );
+    });
+  });
+
+  test('rejects invalid external state monitor interval', () {
+    withTargetPlatform(TargetPlatform.android, () {
+      expect(
+        () => const PipOptions(externalStateMonitorInterval: 0).toDictionary(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  test('rejects invalid iOS preferred content dimensions', () {
+    withTargetPlatform(TargetPlatform.iOS, () {
+      expect(
+        () => const PipOptions(preferredContentWidth: 0).toDictionary(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => const PipOptions(preferredContentHeight: -1).toDictionary(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  test('rejects invalid iOS control style', () {
+    withTargetPlatform(TargetPlatform.iOS, () {
+      expect(
+        () => const PipOptions(controlStyle: -1).toDictionary(),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => const PipOptions(controlStyle: 4).toDictionary(),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  test('ignores invalid options for inactive platforms', () {
+    withTargetPlatform(TargetPlatform.iOS, () {
+      expect(
+        const PipOptions(aspectRatioX: 16).toDictionary(),
+        isNot(contains('aspectRatioX')),
+      );
+    });
+
+    withTargetPlatform(TargetPlatform.android, () {
+      expect(
+        const PipOptions(controlStyle: 4).toDictionary(),
+        isNot(contains('controlStyle')),
+      );
+    });
   });
 
   test('notifies registered observers when native state changes', () async {
@@ -335,4 +462,14 @@ void main() {
       expect(receivedState, PipState.pipStateStopped);
     },
   );
+}
+
+void withTargetPlatform(TargetPlatform platform, void Function() body) {
+  final previousPlatform = debugDefaultTargetPlatformOverride;
+  debugDefaultTargetPlatformOverride = platform;
+  try {
+    body();
+  } finally {
+    debugDefaultTargetPlatformOverride = previousPlatform;
+  }
 }


### PR DESCRIPTION
## Summary
- add platform-aware Dart validation for PipOptions before serializing setup payloads
- reject invalid Android aspect ratio/source rect/monitor interval values and invalid iOS sizing/control style values
- keep inactive platform options ignored and preserve Android empty source rect compatibility

## Verification
- flutter test test/pip_method_channel_test.dart
- flutter test
- flutter analyze
- ./scripts/check_spm.sh
- ./scripts/check.sh

## Review
- subagent spec review: passed
- subagent code quality review: passed