### PR TITLE
feat: add isActive API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bool isPipSupported = await _pip.isSupported();
 bool isPipAutoEnterSupported = await _pip.isAutoEnterSupported();
 
 // Check if currently in PiP mode
-bool isPipActived = await _pip.isActived();
+bool isPipActive = await _pip.isActive();
 ```
 
 ### 2. PiP Configuration
@@ -156,6 +156,9 @@ Future<bool> isSupported()
 Future<bool> isAutoEnterSupported()
 
 // Check if PiP is currently active
+Future<bool> isActive()
+
+// Deprecated: use isActive() in new code
 Future<bool> isActived()
 ```
 

--- a/example/integration_test/plugin_integration_test.dart
+++ b/example/integration_test/plugin_integration_test.dart
@@ -6,7 +6,6 @@
 // For more information about Flutter integration tests, please see
 // https://flutter.dev/to/integration-testing
 
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -15,11 +14,10 @@ import 'package:pip/pip.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('isActived test', (WidgetTester tester) async {
+  testWidgets('isActive test', (WidgetTester tester) async {
     final Pip plugin = Pip();
-    final bool isActived = await plugin.isActived();
-    // The version string depends on the host platform running the test, so
-    // just assert that some non-empty string is returned.
-    expect(isActived, false);
+    final bool isActive = await plugin.isActive();
+
+    expect(isActive, false);
   });
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -64,19 +64,21 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
 
-    // We highly recommend to set the aspect ratio or preferred width and height based on the screen size, 
+    // We highly recommend to set the aspect ratio or preferred width and height based on the screen size,
     // which will make the PiP experience more seamless.
-    
+
     // Initialize controllers with default values based on platform
     final view = WidgetsBinding.instance.platformDispatcher.views.first;
     final size = view.physicalSize;
     final scale = view.devicePixelRatio;
     final width = size.width / scale;
     final height = size.height / scale;
-    
+
     if (Platform.isIOS) {
-      _aspectRatioXController = TextEditingController(text: width.toStringAsFixed(0));
-      _aspectRatioYController = TextEditingController(text: height.toStringAsFixed(0));
+      _aspectRatioXController =
+          TextEditingController(text: width.toStringAsFixed(0));
+      _aspectRatioYController =
+          TextEditingController(text: height.toStringAsFixed(0));
     } else {
       // Find the simplest ratio that matches the aspect ratio
       int gcd(int a, int b) {
@@ -87,15 +89,15 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
         }
         return a;
       }
-      
+
       final divisor = gcd(width.toInt(), height.toInt());
       final x = (width / divisor).round();
       final y = (height / divisor).round();
-      
+
       _aspectRatioXController = TextEditingController(text: x.toString());
       _aspectRatioYController = TextEditingController(text: y.toString());
     }
-    
+
     initPlatformState();
     if (Platform.isAndroid) {
       _startImageTimer();
@@ -178,7 +180,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
       debugPrint('[platformVersion]: $platformVersion');
       pipIsSupported = await _pip.isSupported();
       pipIsAutoEnterSupported = await _pip.isAutoEnterSupported();
-      isPipActived = await _pip.isActived();
+      isPipActived = await _pip.isActive();
       await _pip.registerStateChangedObserver(PipStateChangedObserver(
         onPipStateChanged: (state, error) {
           debugPrint('[onPipStateChanged] state: $state, error: $error');
@@ -293,7 +295,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
                 final size = MediaQuery.of(context).size;
                 final imageWidth = size.width;
                 final imageHeight = size.height;
-                
+
                 return Image.asset(
                   _imagePaths[_currentImageIndex],
                   width: imageWidth,

--- a/lib/pip.dart
+++ b/lib/pip.dart
@@ -5,7 +5,8 @@ export 'pip_platform_interface.dart'
 
 class Pip {
   Future<void> registerStateChangedObserver(
-      PipStateChangedObserver observer) async {
+    PipStateChangedObserver observer,
+  ) async {
     return PipPlatform.instance.registerStateChangedObserver(observer);
   }
 
@@ -30,12 +31,21 @@ class Pip {
     return PipPlatform.instance.isAutoEnterSupported();
   }
 
-  /// Check if Picture in Picture is actived.
+  /// Check if Picture in Picture is active.
   ///
   /// Returns
-  /// Whether Picture in Picture is actived.
+  /// Whether Picture in Picture is active.
+  Future<bool> isActive() async {
+    return PipPlatform.instance.isActive();
+  }
+
+  /// Check if Picture in Picture is active.
+  ///
+  /// Returns
+  /// Whether Picture in Picture is active.
+  @Deprecated('Use isActive instead.')
   Future<bool> isActived() async {
-    return PipPlatform.instance.isActived();
+    return PipPlatform.instance.isActive();
   }
 
   /// Setup or update Picture in Picture.

--- a/lib/pip_method_channel.dart
+++ b/lib/pip_method_channel.dart
@@ -65,9 +65,14 @@ class MethodChannelPip extends PipPlatform {
   }
 
   @override
-  Future<bool> isActived() async {
+  Future<bool> isActive() async {
     final result = await methodChannel.invokeMethod<bool>('isActived', null);
     return result ?? false;
+  }
+
+  @override
+  Future<bool> isActived() async {
+    return isActive();
   }
 
   @override

--- a/lib/pip_platform_interface.dart
+++ b/lib/pip_platform_interface.dart
@@ -332,10 +332,20 @@ abstract class PipPlatform extends PlatformInterface {
     );
   }
 
-  /// Check if Picture in Picture is actived.
+  /// Check if Picture in Picture is active.
   ///
   /// Returns
-  /// Whether Picture in Picture is actived.
+  /// Whether Picture in Picture is active.
+  Future<bool> isActive() async {
+    // ignore: deprecated_member_use_from_same_package
+    return isActived();
+  }
+
+  /// Check if Picture in Picture is active.
+  ///
+  /// Returns
+  /// Whether Picture in Picture is active.
+  @Deprecated('Use isActive instead.')
   Future<bool> isActived() async {
     throw UnimplementedError('isActived() has not been implemented.');
   }

--- a/test/pip_method_channel_test.dart
+++ b/test/pip_method_channel_test.dart
@@ -47,7 +47,9 @@ void main() {
   test('forwards platform method calls to the native channel', () async {
     expect(await platform.isSupported(), isTrue);
     expect(await platform.isAutoEnterSupported(), isTrue);
+    // ignore: deprecated_member_use_from_same_package
     expect(await platform.isActived(), isFalse);
+    expect(await platform.isActive(), isFalse);
     expect(
       await platform.setup(const PipOptions(autoEnterEnabled: true)),
       isTrue,
@@ -59,6 +61,7 @@ void main() {
     expect(methodCalls.map((call) => call.method), <String>[
       'isSupported',
       'isAutoEnterSupported',
+      'isActived',
       'isActived',
       'setup',
       'start',

--- a/test/pip_test.dart
+++ b/test/pip_test.dart
@@ -12,7 +12,8 @@ class MockPipPlatform with MockPlatformInterfaceMixin implements PipPlatform {
 
   @override
   Future<void> registerStateChangedObserver(
-      PipStateChangedObserver observer) async {
+    PipStateChangedObserver observer,
+  ) async {
     this.observer = observer;
   }
 
@@ -28,7 +29,10 @@ class MockPipPlatform with MockPlatformInterfaceMixin implements PipPlatform {
   Future<bool> isAutoEnterSupported() async => true;
 
   @override
-  Future<bool> isActived() async => false;
+  Future<bool> isActive() async => false;
+
+  @override
+  Future<bool> isActived() async => true;
 
   @override
   Future<bool> setup(PipOptions options) async {
@@ -78,6 +82,8 @@ void main() {
 
     expect(await pip.isSupported(), isTrue);
     expect(await pip.isAutoEnterSupported(), isTrue);
+    expect(await pip.isActive(), isFalse);
+    // ignore: deprecated_member_use_from_same_package
     expect(await pip.isActived(), isFalse);
     expect(await pip.setup(const PipOptions(autoEnterEnabled: true)), isTrue);
     expect(fakePlatform.lastOptions?.autoEnterEnabled, isTrue);


### PR DESCRIPTION
## Summary
- add the new Pip.isActive() and PipPlatform.isActive() API while keeping isActived() as a deprecated compatibility alias
- keep MethodChannel traffic on the existing native isActived method name to avoid native breaking changes
- update README and example usages to prefer isActive()

## Verification
- flutter test test/pip_test.dart test/pip_method_channel_test.dart
- flutter test
- flutter analyze
- ./scripts/check_spm.sh
- ./scripts/check.sh

## Review
- subagent spec review: passed after fixes
- subagent code quality review: passed after fixes