### PR TITLE
fix: harden Android PiP lifecycle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,7 @@ android {
     dependencies {
         testImplementation("junit:junit:4.13.2")
         testImplementation("org.mockito:mockito-core:5.0.0")
+        testImplementation("org.robolectric:robolectric:4.12.2")
     }
 
     testOptions {

--- a/android/src/main/java/org/opentraa/pip/PipController.java
+++ b/android/src/main/java/org/opentraa/pip/PipController.java
@@ -138,6 +138,18 @@ public class PipController implements PipActivity.PipActivityListener {
 
   public void attachToActivity(@NonNull Activity activity) {
     setActivity(activity);
+    startStateMonitoring();
+  }
+
+  public void detachFromActivity() {
+    stopStateMonitoring();
+    Activity activity = mActivity != null ? mActivity.get() : null;
+    if (activity instanceof PipActivity) {
+      ((PipActivity)activity).setPipActivityListener(null);
+    }
+    mActivity = new WeakReference<Activity>(null);
+    mIsSupported = false;
+    mIsAutoEnterSupported = false;
   }
 
   public boolean isSupported() { return mIsSupported; }
@@ -300,6 +312,10 @@ public class PipController implements PipActivity.PipActivityListener {
   }
 
   private void startStateMonitoring() {
+    if (mPipParams == null) {
+      return;
+    }
+
     // Do not need to monitor the pip state with external thread when the
     // activity is kind of PipActivity and the external state monitor is
     // not enabled
@@ -334,20 +350,19 @@ public class PipController implements PipActivity.PipActivityListener {
     if (mHandler != null && mCheckStateTask != null) {
       mHandler.removeCallbacks(mCheckStateTask);
     }
+    mCheckStateTask = null;
   }
 
   @Override
   public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode,
                                             Configuration newConfig) {
-    if (Boolean.TRUE.equals(mPipParams.useExternalStateMonitor)) {
+    if (mPipParams == null ||
+        Boolean.TRUE.equals(mPipParams.useExternalStateMonitor)) {
       return;
     }
 
-    if (isInPictureInPictureMode) {
-      notifyPipStateChanged(PipState.Started);
-    } else {
-      notifyPipStateChanged(PipState.Stopped);
-    }
+    notifyPipStateChanged(isInPictureInPictureMode ? PipState.Started
+                                                   : PipState.Stopped);
   }
 
   @Override
@@ -357,6 +372,10 @@ public class PipController implements PipActivity.PipActivityListener {
 
   @Override
   public void onUserLeaveHint() {
+    if (mPipParams == null) {
+      return;
+    }
+
     // Only need to handle auto enter pip for android version below 12
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
       if (Boolean.TRUE.equals(mPipParams.autoEnterEnabled)) {

--- a/android/src/main/java/org/opentraa/pip/PipPlugin.java
+++ b/android/src/main/java/org/opentraa/pip/PipPlugin.java
@@ -39,6 +39,35 @@ public class PipPlugin
     }
   }
 
+  static Integer parsePositiveInt(Object value) {
+    if (!(value instanceof Integer)) {
+      return null;
+    }
+    Integer intValue = (Integer)value;
+    return intValue > 0 ? intValue : null;
+  }
+
+  static Rect parseSourceRect(Object left, Object top, Object right,
+                              Object bottom) {
+    Integer parsedLeft = left instanceof Integer ? (Integer)left : null;
+    Integer parsedTop = top instanceof Integer ? (Integer)top : null;
+    Integer parsedRight = right instanceof Integer ? (Integer)right : null;
+    Integer parsedBottom = bottom instanceof Integer ? (Integer)bottom : null;
+    if (parsedLeft == null || parsedTop == null || parsedRight == null ||
+        parsedBottom == null) {
+      return null;
+    }
+    boolean isEmptyRect = parsedLeft == 0 && parsedTop == 0 &&
+                          parsedRight == 0 && parsedBottom == 0;
+    if (isEmptyRect) {
+      return new Rect(parsedLeft, parsedTop, parsedRight, parsedBottom);
+    }
+    if (parsedRight <= parsedLeft || parsedBottom <= parsedTop) {
+      return null;
+    }
+    return new Rect(parsedLeft, parsedTop, parsedRight, parsedBottom);
+  }
+
   @Override
   public void
   onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
@@ -61,41 +90,36 @@ public class PipPlugin
         result.success(pipController.isActived());
         break;
       case "setup":
+        if (!(call.arguments instanceof Map)) {
+          result.success(false);
+          break;
+        }
         final Map<?, ?> args = (Map<?, ?>)call.arguments;
         Rational aspectRatio = null;
-        if (args.get("aspectRatioX") != null &&
-            args.get("aspectRatioY") != null) {
-          aspectRatio = new Rational((int)args.get("aspectRatioX"),
-                                     (int)args.get("aspectRatioY"));
+        Integer aspectRatioX = parsePositiveInt(args.get("aspectRatioX"));
+        Integer aspectRatioY = parsePositiveInt(args.get("aspectRatioY"));
+        if (aspectRatioX != null && aspectRatioY != null) {
+          aspectRatio = new Rational(aspectRatioX, aspectRatioY);
         }
-        Boolean autoEnterEnabled = null;
-        if (args.get("autoEnterEnabled") != null) {
-          autoEnterEnabled = (boolean)args.get("autoEnterEnabled");
-        }
-        Rect sourceRectHint = null;
-        if (args.get("sourceRectHintLeft") != null &&
-            args.get("sourceRectHintTop") != null &&
-            args.get("sourceRectHintRight") != null &&
-            args.get("sourceRectHintBottom") != null) {
-          sourceRectHint = new Rect((int)args.get("sourceRectHintLeft"),
-                                    (int)args.get("sourceRectHintTop"),
-                                    (int)args.get("sourceRectHintRight"),
-                                    (int)args.get("sourceRectHintBottom"));
-        }
-        Boolean seamlessResizeEnabled = null;
-        if (args.get("seamlessResizeEnabled") != null) {
-          seamlessResizeEnabled = (boolean)args.get("seamlessResizeEnabled");
-        }
-        Boolean useExternalStateMonitor = null;
-        if (args.get("useExternalStateMonitor") != null) {
-          useExternalStateMonitor =
-              (boolean)args.get("useExternalStateMonitor");
-        }
-        Integer externalStateMonitorInterval = null;
-        if (args.get("externalStateMonitorInterval") != null) {
-          externalStateMonitorInterval =
-              (int)args.get("externalStateMonitorInterval");
-        }
+        Boolean autoEnterEnabled =
+            args.get("autoEnterEnabled") instanceof Boolean
+                ? (Boolean)args.get("autoEnterEnabled")
+                : null;
+        Rect sourceRectHint =
+            parseSourceRect(args.get("sourceRectHintLeft"),
+                            args.get("sourceRectHintTop"),
+                            args.get("sourceRectHintRight"),
+                            args.get("sourceRectHintBottom"));
+        Boolean seamlessResizeEnabled =
+            args.get("seamlessResizeEnabled") instanceof Boolean
+                ? (Boolean)args.get("seamlessResizeEnabled")
+                : null;
+        Boolean useExternalStateMonitor =
+            args.get("useExternalStateMonitor") instanceof Boolean
+                ? (Boolean)args.get("useExternalStateMonitor")
+                : null;
+        Integer externalStateMonitorInterval =
+            parsePositiveInt(args.get("externalStateMonitorInterval"));
         result.success(
             pipController.setup(aspectRatio, autoEnterEnabled, sourceRectHint,
                                 seamlessResizeEnabled, useExternalStateMonitor,
@@ -120,18 +144,19 @@ public class PipPlugin
     }
   }
 
-@Override
-public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+  @Override
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
     if (channel != null) {
-        channel.setMethodCallHandler(null);
-        channel = null;
+      channel.setMethodCallHandler(null);
+      channel = null;
     }
 
     if (pipController != null) {
-        pipController.dispose();
-        pipController = null;
+      pipController.dispose();
+      pipController.detachFromActivity();
+      pipController = null;
     }
-}
+  }
 
   private void initPipController(@NonNull ActivityPluginBinding binding) {
     if (pipController == null) {
@@ -158,7 +183,11 @@ public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
   }
 
   @Override
-  public void onDetachedFromActivityForConfigChanges() {}
+  public void onDetachedFromActivityForConfigChanges() {
+    if (pipController != null) {
+      pipController.detachFromActivity();
+    }
+  }
 
   @Override
   public void onReattachedToActivityForConfigChanges(
@@ -167,5 +196,9 @@ public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
   }
 
   @Override
-  public void onDetachedFromActivity() {}
+  public void onDetachedFromActivity() {
+    if (pipController != null) {
+      pipController.detachFromActivity();
+    }
+  }
 }

--- a/android/src/test/java/org/opentraa/pip/PipPluginTest.java
+++ b/android/src/test/java/org/opentraa/pip/PipPluginTest.java
@@ -1,29 +1,39 @@
 package org.opentraa.pip;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel;
+import android.graphics.Rect;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
-/**
- * This demonstrates a simple unit test of the Java portion of this plugin's implementation.
- *
- * Once you have built the plugin's example app, you can run these tests from the command
- * line by running `./gradlew testDebugUnitTest` in the `example/android/` directory, or
- * you can run them directly from IDEs that support JUnit such as Android Studio.
- */
-
+@RunWith(RobolectricTestRunner.class)
 public class PipPluginTest {
   @Test
-  public void onMethodCall_getPlatformVersion_returnsExpectedValue() {
-    PipPlugin plugin = new PipPlugin();
+  public void parsePositiveIntReturnsNullForInvalidValues() {
+    assertEquals(Integer.valueOf(16), PipPlugin.parsePositiveInt(16));
+    assertNull(PipPlugin.parsePositiveInt(0));
+    assertNull(PipPlugin.parsePositiveInt(-1));
+    assertNull(PipPlugin.parsePositiveInt("16"));
+    assertNull(PipPlugin.parsePositiveInt(null));
+  }
 
-    final MethodCall call = new MethodCall("getPlatformVersion", null);
-    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
-    plugin.onMethodCall(call, mockResult);
+  @Test
+  public void parseSourceRectRejectsPartialOrInvalidRects() {
+    assertNull(PipPlugin.parseSourceRect(0, 0, 0, 10));
+    assertNull(PipPlugin.parseSourceRect(0, null, 10, 10));
 
-    verify(mockResult).success("Android " + android.os.Build.VERSION.RELEASE);
+    Rect emptyRect = PipPlugin.parseSourceRect(0, 0, 0, 0);
+    assertEquals(0, emptyRect.left);
+    assertEquals(0, emptyRect.top);
+    assertEquals(0, emptyRect.right);
+    assertEquals(0, emptyRect.bottom);
+
+    Rect rect = PipPlugin.parseSourceRect(0, 0, 10, 10);
+    assertEquals(0, rect.left);
+    assertEquals(0, rect.top);
+    assertEquals(10, rect.right);
+    assertEquals(10, rect.bottom);
   }
 }


### PR DESCRIPTION
## Summary
- add safe Android setup argument parsing helpers and Robolectric-covered unit tests
- keep all-zero sourceRectHint compatible with Dart setup options
- clean up Activity detach handling and restart guarded state monitoring after reattach

## Verification
- flutter test
- flutter analyze
- ./scripts/check_spm.sh
- ./scripts/check.sh
- android native test not run locally: no gradle or android/gradlew available in this environment; command returned NO_GRADLE_AVAILABLE

## Review
- subagent spec review: passed after fixes
- subagent Android code quality review: passed after fixes