### PR TITLE
fix: harden iOS PiP controller lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ final options = PipOptions(
   contentView: 0,             // Content view to be displayed in PiP
   preferredContentWidth: 480,  // Preferred content width
   preferredContentHeight: 270, // Preferred content height
-  controlStyle: 2,            // Control style for PiP window
+  controlStyle: 1,            // Control style for PiP window
 );
 
 await _pip.setup(options);
@@ -130,9 +130,8 @@ PipOptions({
   int? preferredContentHeight,// Preferred content height
   int? controlStyle,          // Control style for PiP window
                               // 0: default show all system controls
-                              // 1: hide forward and backward button
-                              // 2: hide play pause button and the progress bar including forward and backward button (recommended)
-                              // 3: hide all system controls including the close and restore button
+                              // 1: request documented linear playback behavior
+                              // 2/3: accepted for backward compatibility, but private control hiding is ignored
 })
 ```
 
@@ -208,9 +207,9 @@ Future<void> unregisterStateChangedObserver()
 - The `contentView` will be added to the PiP view after setup, and you are responsible for rendering the content view
 - Choose appropriate `controlStyle` based on your needs:
   - Style 0: Shows all system controls (default)
-  - Style 1: Hides forward and backward buttons
-  - Style 2: Hides play/pause button and progress bar (recommended)
-  - Style 3: Hides all system controls including close and restore buttons
+  - Style 1: Requests documented linear playback behavior, which hides forward and backward controls where AVKit supports it
+  - Styles 2 and 3: Accepted for backward compatibility, but only documented AVKit behavior is applied
+- On iOS, `controlStyle` only uses documented AVKit behavior. Values that require private system control hiding are ignored to avoid App Store review and OS compatibility risk.
 - How to set the size of the PiP window? Just set the `preferredContentWidth` and `preferredContentHeight` in the `PipOptions`
 
 ## Best Practices
@@ -230,7 +229,7 @@ if (Platform.isAndroid) {
     sourceContentView: someOtherView,
     preferredContentWidth: 480,
     preferredContentHeight: 270,
-    controlStyle: 2,
+    controlStyle: 1,
   );
 }
 ```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ PipOptions({
   int? controlStyle,          // Control style for PiP window
                               // 0: default show all system controls
                               // 1: request documented linear playback behavior
-                              // 2/3: accepted for backward compatibility, but private control hiding is ignored
+                              // 2: hide play/pause button and progress bar using private iOS API
+                              // 3: hide all system controls using private iOS API
 })
 ```
 
@@ -208,8 +209,9 @@ Future<void> unregisterStateChangedObserver()
 - Choose appropriate `controlStyle` based on your needs:
   - Style 0: Shows all system controls (default)
   - Style 1: Requests documented linear playback behavior, which hides forward and backward controls where AVKit supports it
-  - Styles 2 and 3: Accepted for backward compatibility, but only documented AVKit behavior is applied
-- On iOS, `controlStyle` only uses documented AVKit behavior. Values that require private system control hiding are ignored to avoid App Store review and OS compatibility risk.
+  - Style 2: Hides play/pause button and progress bar using private iOS API
+  - Style 3: Hides all system controls using private iOS API
+- On iOS, `controlStyle` values 2 and 3 rely on private AVKit behavior. They may break on future iOS versions and can increase App Store review risk.
 - How to set the size of the PiP window? Just set the `preferredContentWidth` and `preferredContentHeight` in the `PipOptions`
 
 ## Best Practices

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -258,7 +258,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
         sourceContentView: _playerView,
         preferredContentWidth: int.tryParse(_aspectRatioXController.text),
         preferredContentHeight: int.tryParse(_aspectRatioYController.text),
-        controlStyle: 2,
+        controlStyle: 1,
       );
 
       try {

--- a/ios/pip/Sources/pip/PipController.m
+++ b/ios/pip/Sources/pip/PipController.m
@@ -18,8 +18,6 @@
 #define PIP_LOG(fmt, ...)
 #endif
 
-#define USE_PIP_VIEW_CONTROLLER 0
-
 @implementation PipOptions {
 }
 @end
@@ -35,7 +33,7 @@
 
 #pragma mark - content view
 // content view
-@property(nonatomic, assign) UIView *contentView;
+@property(nonatomic, weak) UIView *contentView;
 
 // content view original index
 @property(nonatomic, assign) NSUInteger contentViewOriginalIndex;
@@ -51,7 +49,7 @@
     bool contentViewOriginalTranslatesAutoresizingMaskIntoConstraints;
 
 // content view original parent view
-@property(nonatomic, assign) UIView *contentViewOriginalParentView;
+@property(nonatomic, weak) UIView *contentViewOriginalParentView;
 
 // content view original parent view constraints
 @property(nonatomic, strong)
@@ -64,17 +62,44 @@
 // pip controller
 @property(nonatomic, strong) AVPictureInPictureController *pipController;
 
-#if USE_PIP_VIEW_CONTROLLER
-// Do not use this anymore, it is dangerous to use it and do not have the best
-// user experience(we have to call bringToFront in didStart which make the
-// truely pip view not visible for a while ).
-// pip view controller, weak reference
-@property(nonatomic) UIViewController *pipViewController;
-#endif
-
 @end
 
 @implementation PipController
+
+- (void)clearContentViewRestoreSnapshot {
+  [_contentViewOriginalConstraints removeAllObjects];
+  [_contentViewOriginalParentViewConstraints removeAllObjects];
+  _contentViewOriginalParentView = nil;
+  _contentViewOriginalIndex = 0;
+  _contentViewOriginalFrame = CGRectZero;
+  _contentViewOriginalTranslatesAutoresizingMaskIntoConstraints = false;
+}
+
+- (UIWindow *)activeKeyWindow {
+  UIWindow *fallbackKeyWindow = nil;
+
+  for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+    if (![scene isKindOfClass:UIWindowScene.class]) {
+      continue;
+    }
+
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
+    for (UIWindow *window in windowScene.windows) {
+      if (window.isKeyWindow) {
+        if (scene.activationState == UISceneActivationStateForegroundActive ||
+            scene.activationState == UISceneActivationStateForegroundInactive) {
+          return window;
+        }
+
+        if (fallbackKeyWindow == nil) {
+          fallbackKeyWindow = window;
+        }
+      }
+    }
+  }
+
+  return fallbackKeyWindow;
+}
 
 - (instancetype)initWith:(id<PipStateChangedDelegate>)delegate {
   self = [super init];
@@ -113,6 +138,14 @@
 }
 
 - (BOOL)setup:(PipOptions *)options {
+  if (![NSThread isMainThread]) {
+    __block BOOL result = NO;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      result = [self setup:options];
+    });
+    return result;
+  }
+
   PIP_LOG(@"PipController setup with preferredContentSize: %@, "
           @"autoEnterEnabled: %d",
           NSStringFromCGSize(options.preferredContentSize),
@@ -129,10 +162,14 @@
     UIView *currentVideoSourceView =
         (options.sourceContentView != nil)
             ? options.sourceContentView
-            : [UIApplication.sharedApplication.keyWindow rootViewController]
-                  .view;
+            : [self activeKeyWindow].rootViewController.view;
+    if (currentVideoSourceView == nil) {
+      [_pipStateDelegate pipStateChanged:PipStateFailed
+                                   error:@"Pip source view is not available"];
+      return NO;
+    }
 
-    _contentView = (UIView *)options.contentView;
+    UIView *contentView = options.contentView;
 
     // We need to setup or re-setup the pip controller if:
     // 1. The pip controller hasn't been initialized yet (_pipController == nil)
@@ -148,6 +185,7 @@
 
       // create pip view
       _pipView = [[PipView alloc] init];
+      _contentView = contentView;
 
       [currentVideoSourceView insertSubview:_pipView atIndex:0];
 
@@ -182,27 +220,6 @@
       _pipController.canStartPictureInPictureAutomaticallyFromInline =
           options.autoEnterEnabled;
 
-      // hide forward and backward button
-      if (options.controlStyle >= 1) {
-        _pipController.requiresLinearPlayback = YES;
-      }
-
-      if (options.controlStyle == 2) {
-        // hide play pause button and the progress bar including forward and
-        // backward button
-        [_pipController setValue:[NSNumber numberWithInt:1]
-                          forKey:@"controlsStyle"];
-      } else if (options.controlStyle == 3) {
-        // hide all system controls including the close and restore button
-        [_pipController setValue:[NSNumber numberWithInt:2]
-                          forKey:@"controlsStyle"];
-      }
-
-#if USE_PIP_VIEW_CONTROLLER
-      NSString *pipVCName =
-          [NSString stringWithFormat:@"pictureInPictureViewController"];
-      _pipViewController = [_pipController valueForKey:pipVCName];
-#endif
     } else {
       // pip controller is already initialized, so we need to update the options
 
@@ -212,12 +229,12 @@
       // if _contentView is not equal to options.contentView, it means the
       // content view has been changed, so we need to remove the old content
       // view and add the new one.
-      if (_contentView != options.contentView) {
+      if (_contentView != contentView) {
         if (_contentView != nil) {
           [self restoreContentViewIfNeeded];
         }
 
-        _contentView = (UIView *)options.contentView;
+        _contentView = contentView;
       }
 
       if (options.preferredContentSize.width > 0 &&
@@ -234,6 +251,8 @@
       }
     }
 
+    _pipController.requiresLinearPlayback = options.controlStyle >= 1;
+
     return YES;
   }
 
@@ -245,6 +264,14 @@
 }
 
 - (BOOL)start {
+  if (![NSThread isMainThread]) {
+    __block BOOL result = NO;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      result = [self start];
+    });
+    return result;
+  }
+
   PIP_LOG(@"PipController start");
 
   if (![self isSupported]) {
@@ -276,6 +303,13 @@
 }
 
 - (void)stop {
+  if (![NSThread isMainThread]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self stop];
+    });
+    return;
+  }
+
   PIP_LOG(@"PipController stop");
 
   if (![self isSupported]) {
@@ -319,6 +353,7 @@
   }
 
   // save the original content view properties
+  [self clearContentViewRestoreSnapshot];
   _contentViewOriginalParentView = _contentView.superview;
   if (_contentViewOriginalParentView != nil) {
     _contentViewOriginalIndex =
@@ -378,6 +413,7 @@
     PIP_LOG(
         @"restoreContentViewIfNeeded: _contentViewOriginalParentView is nil or "
         @"contentView is already in the original parent view");
+    [self clearContentViewRestoreSnapshot];
     return;
   }
 
@@ -413,9 +449,18 @@
       removeConstraints:_contentViewOriginalParentView.constraints.copy];
   [_contentViewOriginalParentView
       addConstraints:_contentViewOriginalParentViewConstraints];
+
+  [self clearContentViewRestoreSnapshot];
 }
 
 - (void)dispose {
+  if (![NSThread isMainThread]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self dispose];
+    });
+    return;
+  }
+
   PIP_LOG(@"PipController dispose");
 
   if (self->_pipController != nil) {
@@ -457,35 +502,18 @@
     (AVPictureInPictureController *)pictureInPictureController {
   PIP_LOG(@"pictureInPictureControllerWillStartPictureInPicture");
 
-#if USE_PIP_VIEW_CONTROLLER
-  if (_pipViewController) {
-    [self insertContentViewIfNeeded:_pipViewController.view];
-  }
-#endif
 }
 
 - (void)pictureInPictureControllerDidStartPictureInPicture:
     (AVPictureInPictureController *)pictureInPictureController {
   PIP_LOG(@"pictureInPictureControllerDidStartPictureInPicture");
 
-#if USE_PIP_VIEW_CONTROLLER
-  // if you use the pipViewController, you must call this every time to bring
-  // the content view to the front, otherwise the content view will not be
-  // visible and covered by the pip host view.
-  if (_pipViewController) {
-    [_pipViewController.view bringSubviewToFront:_contentView];
-  }
-#else
-  // TODO @sylar: check if this is the best way to do this, what will happen if
-  // we have multiple windows? what if the root view controller is not a
-  // UIViewController?
-  UIWindow *window = [[UIApplication sharedApplication] windows].firstObject;
+  UIWindow *window = [self activeKeyWindow];
   if (window) {
     UIViewController *rootViewController = window.rootViewController;
     UIView *superview = rootViewController.view.superview;
     [self insertContentViewIfNeeded:superview];
   }
-#endif
 
   _isPipActived = YES;
   [_pipStateDelegate pipStateChanged:PipStateStarted error:nil];

--- a/ios/pip/Sources/pip/PipController.m
+++ b/ios/pip/Sources/pip/PipController.m
@@ -62,6 +62,8 @@
 // pip controller
 @property(nonatomic, strong) AVPictureInPictureController *pipController;
 
+@property(nonatomic, assign) BOOL privateControlsStyleApplied;
+
 @end
 
 @implementation PipController
@@ -99,6 +101,31 @@
   }
 
   return fallbackKeyWindow;
+}
+
+- (void)applyControlStyle:(int)controlStyle {
+  _pipController.requiresLinearPlayback = controlStyle >= 1;
+
+  NSNumber *privateControlsStyle = nil;
+  if (controlStyle == 2) {
+    privateControlsStyle = @1;
+  } else if (controlStyle == 3) {
+    privateControlsStyle = @2;
+  } else if (_privateControlsStyleApplied) {
+    privateControlsStyle = @0;
+  }
+
+  if (privateControlsStyle == nil) {
+    return;
+  }
+
+  @try {
+    [_pipController setValue:privateControlsStyle forKey:@"controlsStyle"];
+    _privateControlsStyleApplied = privateControlsStyle.intValue != 0;
+  } @catch (NSException *exception) {
+    PIP_LOG(@"Failed to apply private controlsStyle %@: %@",
+            privateControlsStyle, exception.reason);
+  }
 }
 
 - (instancetype)initWith:(id<PipStateChangedDelegate>)delegate {
@@ -217,6 +244,7 @@
       _pipController = [[AVPictureInPictureController alloc]
           initWithContentSource:contentSource];
       _pipController.delegate = self;
+      _privateControlsStyleApplied = NO;
       _pipController.canStartPictureInPictureAutomaticallyFromInline =
           options.autoEnterEnabled;
 
@@ -251,7 +279,7 @@
       }
     }
 
-    _pipController.requiresLinearPlayback = options.controlStyle >= 1;
+    [self applyControlStyle:options.controlStyle];
 
     return YES;
   }

--- a/ios/pip/Sources/pip/include/pip/PipController.h
+++ b/ios/pip/Sources/pip/include/pip/PipController.h
@@ -43,13 +43,13 @@ typedef NS_ENUM(NSInteger, PipState) {
  * @abstract The source content view for pip, set to nil will use the root
  * view of the application as the source content view.
  */
-@property(nonatomic, assign) UIView *_Nullable sourceContentView;
+@property(nonatomic, nullable, weak) UIView *sourceContentView;
 
 /**
  * @property contentView
  * @abstract The content view for pip.
  */
-@property(nonatomic, assign) UIView *_Nullable contentView;
+@property(nonatomic, nullable, weak) UIView *contentView;
 
 /**
  * @property autoEnterEnabled

--- a/lib/pip_platform_interface.dart
+++ b/lib/pip_platform_interface.dart
@@ -84,9 +84,8 @@ class PipOptions {
   /// The control style of the content view.
   ///
   /// 0: default show all system controls
-  /// 1: hide forward and backward button
-  /// 2: hide play pause button and the progress bar including forward and backward button (recommended)
-  /// 3: hide all system controls including the close and restore button
+  /// 1: request documented linear playback behavior
+  /// 2/3: accepted for backward compatibility, but private control hiding is ignored on iOS
   final int? controlStyle;
 
   /// Convert the options to a dictionary.

--- a/lib/pip_platform_interface.dart
+++ b/lib/pip_platform_interface.dart
@@ -85,7 +85,8 @@ class PipOptions {
   ///
   /// 0: default show all system controls
   /// 1: request documented linear playback behavior
-  /// 2/3: accepted for backward compatibility, but private control hiding is ignored on iOS
+  /// 2: hide play/pause button and progress bar using private iOS API
+  /// 3: hide all system controls using private iOS API
   final int? controlStyle;
 
   /// Convert the options to a dictionary.


### PR DESCRIPTION
## Summary
- Harden iOS PiP view ownership by using weak UIKit view references, clearing restore snapshots, and routing controller lifecycle calls to the main thread.
- Keep existing iOS `controlStyle` 2/3 behavior by applying the private AVKit `controlsStyle` KVC through one guarded method with exception handling.
- Update README and Dart API docs to explicitly call out that iOS `controlStyle` 2/3 depend on private AVKit behavior and may carry OS/App Store risk.

## Validation
- `./scripts/check.sh`
- `./scripts/check_spm.sh`
- `xcrun --sdk iphoneos clang -x objective-c -fobjc-arc -mios-version-min=15.0 -isysroot "$SDK" -I/tmp/pip-objc-compile -Iios/pip/Sources/pip/include -fsyntax-only ios/pip/Sources/pip/PipController.m`

## Notes
- `flutter build ios --no-codesign` could not complete locally because this machine has no CocoaPods installed. With SPM enabled, Flutter/Xcode also stops in the example app dependency setup before reaching plugin compilation.
- The private `controlsStyle` path is intentionally preserved because there is no public AVKit replacement for hiding these PiP controls.
