### PR TITLE
[codex] redo PR 05 iOS lifecycle hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ final options = PipOptions(
   contentView: 0,             // Content view to be displayed in PiP
   preferredContentWidth: 480,  // Preferred content width
   preferredContentHeight: 270, // Preferred content height
-  controlStyle: 2,            // Control style for PiP window
+  controlStyle: 1,            // Control style for PiP window
 );
 
 await _pip.setup(options);
@@ -130,9 +130,9 @@ PipOptions({
   int? preferredContentHeight,// Preferred content height
   int? controlStyle,          // Control style for PiP window
                               // 0: default show all system controls
-                              // 1: hide forward and backward button
-                              // 2: hide play pause button and the progress bar including forward and backward button (recommended)
-                              // 3: hide all system controls including the close and restore button
+                              // 1: request documented linear playback behavior
+                              // 2: hide play/pause button and progress bar using private iOS API
+                              // 3: hide all system controls using private iOS API
 })
 ```
 
@@ -208,9 +208,10 @@ Future<void> unregisterStateChangedObserver()
 - The `contentView` will be added to the PiP view after setup, and you are responsible for rendering the content view
 - Choose appropriate `controlStyle` based on your needs:
   - Style 0: Shows all system controls (default)
-  - Style 1: Hides forward and backward buttons
-  - Style 2: Hides play/pause button and progress bar (recommended)
-  - Style 3: Hides all system controls including close and restore buttons
+  - Style 1: Requests documented linear playback behavior, which hides forward and backward controls where AVKit supports it
+  - Style 2: Hides play/pause button and progress bar using private iOS API
+  - Style 3: Hides all system controls using private iOS API
+- On iOS, `controlStyle` values 2 and 3 rely on private AVKit behavior. They may break on future iOS versions and can increase App Store review risk.
 - How to set the size of the PiP window? Just set the `preferredContentWidth` and `preferredContentHeight` in the `PipOptions`
 
 ## Best Practices
@@ -230,7 +231,7 @@ if (Platform.isAndroid) {
     sourceContentView: someOtherView,
     preferredContentWidth: 480,
     preferredContentHeight: 270,
-    controlStyle: 2,
+    controlStyle: 1,
   );
 }
 ```

--- a/example/ios/RunnerTests/RunnerTests.swift
+++ b/example/ios/RunnerTests/RunnerTests.swift
@@ -1,12 +1,136 @@
-import Flutter
-import UIKit
+import ObjectiveC.runtime
 import XCTest
 
-class RunnerTests: XCTestCase {
+@objcMembers
+private final class FakePictureInPictureController: NSObject {
+  dynamic var requiresLinearPlayback = false
+  private(set) var appliedControlStyles: [NSNumber] = []
 
-  func testExample() {
-    // If you add code to the Runner application, consider adding tests here.
-    // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+  override func setValue(_ value: Any?, forKey key: String) {
+    if key == "controlsStyle" {
+      if let number = value as? NSNumber {
+        appliedControlStyles.append(number)
+      }
+      return
+    }
+
+    super.setValue(value, forKey: key)
+  }
+}
+
+final class RunnerTests: XCTestCase {
+  func testPipOptionsViewPropertiesUseWeakReferences() {
+    guard let pipOptionsClass = NSClassFromString("PipOptions") else {
+      return XCTFail("PipOptions class not found at runtime")
+    }
+
+    assertPropertyAttributes(
+      of: pipOptionsClass,
+      named: "sourceContentView",
+      contains: "W"
+    )
+    assertPropertyAttributes(
+      of: pipOptionsClass,
+      named: "contentView",
+      contains: "W"
+    )
   }
 
+  func testPipControllerInternalViewPropertiesUseWeakReferences() {
+    guard let pipControllerClass = NSClassFromString("PipController") else {
+      return XCTFail("PipController class not found at runtime")
+    }
+
+    assertPropertyAttributes(
+      of: pipControllerClass,
+      named: "contentView",
+      contains: "W"
+    )
+    assertPropertyAttributes(
+      of: pipControllerClass,
+      named: "contentViewOriginalParentView",
+      contains: "W"
+    )
+  }
+
+  func testPipControllerKeepsPrivateControlStyleEntryPoint() {
+    guard let pipControllerClass = NSClassFromString("PipController") else {
+      return XCTFail("PipController class not found at runtime")
+    }
+
+    XCTAssertNotNil(
+      class_getInstanceMethod(
+        pipControllerClass,
+        NSSelectorFromString("applyControlStyle:")
+      ),
+      "Expected PipController to keep the private control-style entry point"
+    )
+    assertPropertyAttributes(
+      of: pipControllerClass,
+      named: "privateControlsStyleApplied",
+      contains: "TB"
+    )
+  }
+
+  func testPipControllerAppliesAndResetsPrivateControlStyles() {
+    guard let pipControllerClass = NSClassFromString("PipController") as? NSObject.Type else {
+      return XCTFail("PipController class not found at runtime")
+    }
+
+    let controller = pipControllerClass.init()
+    let fakePictureInPictureController = FakePictureInPictureController()
+    controller.setValue(fakePictureInPictureController, forKey: "pipController")
+
+    let applySelector = NSSelectorFromString("applyControlStyle:")
+    XCTAssertTrue(controller.responds(to: applySelector))
+    guard let method = class_getInstanceMethod(pipControllerClass, applySelector) else {
+      return XCTFail("applyControlStyle: method not found")
+    }
+    typealias ApplyControlStyleFn = @convention(c) (AnyObject, Selector, Int32) -> Void
+    let implementation = method_getImplementation(method)
+    let applyControlStyle = unsafeBitCast(
+      implementation,
+      to: ApplyControlStyleFn.self
+    )
+
+    applyControlStyle(controller, applySelector, 2)
+    XCTAssertTrue(fakePictureInPictureController.requiresLinearPlayback)
+    XCTAssertEqual(fakePictureInPictureController.appliedControlStyles.last, 1)
+
+    applyControlStyle(controller, applySelector, 0)
+    XCTAssertFalse(fakePictureInPictureController.requiresLinearPlayback)
+    XCTAssertEqual(fakePictureInPictureController.appliedControlStyles.last, 0)
+  }
+
+  private func assertPropertyAttributes(
+    of cls: AnyClass,
+    named propertyName: String,
+    contains expectedFragment: String,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
+    guard let property = class_getProperty(cls, propertyName) else {
+      return XCTFail(
+        "Expected property \(propertyName) on \(NSStringFromClass(cls))",
+        file: file,
+        line: line
+      )
+    }
+
+    guard let rawAttributes = property_getAttributes(property) else {
+      return XCTFail(
+        "Expected attributes for \(propertyName) on \(NSStringFromClass(cls))",
+        file: file,
+        line: line
+      )
+    }
+
+    let attributes = String(cString: rawAttributes)
+    XCTAssertTrue(
+      attributes.contains(expectedFragment),
+      "Expected \(propertyName) attributes to contain \(expectedFragment), got \(attributes)",
+      file: file,
+      line: line
+    )
+  }
 }

--- a/ios/pip/Sources/pip/PipController.m
+++ b/ios/pip/Sources/pip/PipController.m
@@ -18,8 +18,6 @@
 #define PIP_LOG(fmt, ...)
 #endif
 
-#define USE_PIP_VIEW_CONTROLLER 0
-
 @implementation PipOptions {
 }
 @end
@@ -35,7 +33,7 @@
 
 #pragma mark - content view
 // content view
-@property(nonatomic, assign) UIView *contentView;
+@property(nonatomic, weak) UIView *contentView;
 
 // content view original index
 @property(nonatomic, assign) NSUInteger contentViewOriginalIndex;
@@ -51,7 +49,7 @@
     bool contentViewOriginalTranslatesAutoresizingMaskIntoConstraints;
 
 // content view original parent view
-@property(nonatomic, assign) UIView *contentViewOriginalParentView;
+@property(nonatomic, weak) UIView *contentViewOriginalParentView;
 
 // content view original parent view constraints
 @property(nonatomic, strong)
@@ -63,18 +61,73 @@
 
 // pip controller
 @property(nonatomic, strong) AVPictureInPictureController *pipController;
-
-#if USE_PIP_VIEW_CONTROLLER
-// Do not use this anymore, it is dangerous to use it and do not have the best
-// user experience(we have to call bringToFront in didStart which make the
-// truely pip view not visible for a while ).
-// pip view controller, weak reference
-@property(nonatomic) UIViewController *pipViewController;
-#endif
+@property(nonatomic, assign) BOOL privateControlsStyleApplied;
 
 @end
 
 @implementation PipController
+
+- (void)clearContentViewRestoreSnapshot {
+  [_contentViewOriginalConstraints removeAllObjects];
+  [_contentViewOriginalParentViewConstraints removeAllObjects];
+  _contentViewOriginalParentView = nil;
+  _contentViewOriginalIndex = 0;
+  _contentViewOriginalFrame = CGRectZero;
+  _contentViewOriginalTranslatesAutoresizingMaskIntoConstraints = false;
+}
+
+- (UIWindow *)activeKeyWindow {
+  UIWindow *fallbackKeyWindow = nil;
+
+  for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+    if (![scene isKindOfClass:UIWindowScene.class]) {
+      continue;
+    }
+
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
+    for (UIWindow *window in windowScene.windows) {
+      if (!window.isKeyWindow) {
+        continue;
+      }
+
+      if (scene.activationState == UISceneActivationStateForegroundActive ||
+          scene.activationState == UISceneActivationStateForegroundInactive) {
+        return window;
+      }
+
+      if (fallbackKeyWindow == nil) {
+        fallbackKeyWindow = window;
+      }
+    }
+  }
+
+  return fallbackKeyWindow;
+}
+
+- (void)applyControlStyle:(int)controlStyle {
+  _pipController.requiresLinearPlayback = controlStyle >= 1;
+
+  NSNumber *privateControlsStyle = nil;
+  if (controlStyle == 2) {
+    privateControlsStyle = @1;
+  } else if (controlStyle == 3) {
+    privateControlsStyle = @2;
+  } else if (_privateControlsStyleApplied) {
+    privateControlsStyle = @0;
+  }
+
+  if (privateControlsStyle == nil) {
+    return;
+  }
+
+  @try {
+    [_pipController setValue:privateControlsStyle forKey:@"controlsStyle"];
+    _privateControlsStyleApplied = privateControlsStyle.intValue != 0;
+  } @catch (NSException *exception) {
+    PIP_LOG(@"Failed to apply private controlsStyle %@: %@",
+            privateControlsStyle, exception.reason);
+  }
+}
 
 - (instancetype)initWith:(id<PipStateChangedDelegate>)delegate {
   self = [super init];
@@ -113,6 +166,14 @@
 }
 
 - (BOOL)setup:(PipOptions *)options {
+  if (![NSThread isMainThread]) {
+    __block BOOL result = NO;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      result = [self setup:options];
+    });
+    return result;
+  }
+
   PIP_LOG(@"PipController setup with preferredContentSize: %@, "
           @"autoEnterEnabled: %d",
           NSStringFromCGSize(options.preferredContentSize),
@@ -129,10 +190,14 @@
     UIView *currentVideoSourceView =
         (options.sourceContentView != nil)
             ? options.sourceContentView
-            : [UIApplication.sharedApplication.keyWindow rootViewController]
-                  .view;
+            : [self activeKeyWindow].rootViewController.view;
+    if (currentVideoSourceView == nil) {
+      [_pipStateDelegate pipStateChanged:PipStateFailed
+                                   error:@"Pip source view is not available"];
+      return NO;
+    }
 
-    _contentView = (UIView *)options.contentView;
+    UIView *contentView = options.contentView;
 
     // We need to setup or re-setup the pip controller if:
     // 1. The pip controller hasn't been initialized yet (_pipController == nil)
@@ -148,6 +213,7 @@
 
       // create pip view
       _pipView = [[PipView alloc] init];
+      _contentView = contentView;
 
       [currentVideoSourceView insertSubview:_pipView atIndex:0];
 
@@ -179,30 +245,9 @@
       _pipController = [[AVPictureInPictureController alloc]
           initWithContentSource:contentSource];
       _pipController.delegate = self;
+      _privateControlsStyleApplied = NO;
       _pipController.canStartPictureInPictureAutomaticallyFromInline =
           options.autoEnterEnabled;
-
-      // hide forward and backward button
-      if (options.controlStyle >= 1) {
-        _pipController.requiresLinearPlayback = YES;
-      }
-
-      if (options.controlStyle == 2) {
-        // hide play pause button and the progress bar including forward and
-        // backward button
-        [_pipController setValue:[NSNumber numberWithInt:1]
-                          forKey:@"controlsStyle"];
-      } else if (options.controlStyle == 3) {
-        // hide all system controls including the close and restore button
-        [_pipController setValue:[NSNumber numberWithInt:2]
-                          forKey:@"controlsStyle"];
-      }
-
-#if USE_PIP_VIEW_CONTROLLER
-      NSString *pipVCName =
-          [NSString stringWithFormat:@"pictureInPictureViewController"];
-      _pipViewController = [_pipController valueForKey:pipVCName];
-#endif
     } else {
       // pip controller is already initialized, so we need to update the options
 
@@ -212,12 +257,12 @@
       // if _contentView is not equal to options.contentView, it means the
       // content view has been changed, so we need to remove the old content
       // view and add the new one.
-      if (_contentView != options.contentView) {
+      if (_contentView != contentView) {
         if (_contentView != nil) {
           [self restoreContentViewIfNeeded];
         }
 
-        _contentView = (UIView *)options.contentView;
+        _contentView = contentView;
       }
 
       if (options.preferredContentSize.width > 0 &&
@@ -234,6 +279,8 @@
       }
     }
 
+    [self applyControlStyle:options.controlStyle];
+
     return YES;
   }
 
@@ -245,6 +292,14 @@
 }
 
 - (BOOL)start {
+  if (![NSThread isMainThread]) {
+    __block BOOL result = NO;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      result = [self start];
+    });
+    return result;
+  }
+
   PIP_LOG(@"PipController start");
 
   if (![self isSupported]) {
@@ -276,6 +331,13 @@
 }
 
 - (void)stop {
+  if (![NSThread isMainThread]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self stop];
+    });
+    return;
+  }
+
   PIP_LOG(@"PipController stop");
 
   if (![self isSupported]) {
@@ -319,6 +381,7 @@
   }
 
   // save the original content view properties
+  [self clearContentViewRestoreSnapshot];
   _contentViewOriginalParentView = _contentView.superview;
   if (_contentViewOriginalParentView != nil) {
     _contentViewOriginalIndex =
@@ -378,6 +441,7 @@
     PIP_LOG(
         @"restoreContentViewIfNeeded: _contentViewOriginalParentView is nil or "
         @"contentView is already in the original parent view");
+    [self clearContentViewRestoreSnapshot];
     return;
   }
 
@@ -413,9 +477,18 @@
       removeConstraints:_contentViewOriginalParentView.constraints.copy];
   [_contentViewOriginalParentView
       addConstraints:_contentViewOriginalParentViewConstraints];
+
+  [self clearContentViewRestoreSnapshot];
 }
 
 - (void)dispose {
+  if (![NSThread isMainThread]) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self dispose];
+    });
+    return;
+  }
+
   PIP_LOG(@"PipController dispose");
 
   if (self->_pipController != nil) {
@@ -456,36 +529,18 @@
 - (void)pictureInPictureControllerWillStartPictureInPicture:
     (AVPictureInPictureController *)pictureInPictureController {
   PIP_LOG(@"pictureInPictureControllerWillStartPictureInPicture");
-
-#if USE_PIP_VIEW_CONTROLLER
-  if (_pipViewController) {
-    [self insertContentViewIfNeeded:_pipViewController.view];
-  }
-#endif
 }
 
 - (void)pictureInPictureControllerDidStartPictureInPicture:
     (AVPictureInPictureController *)pictureInPictureController {
   PIP_LOG(@"pictureInPictureControllerDidStartPictureInPicture");
 
-#if USE_PIP_VIEW_CONTROLLER
-  // if you use the pipViewController, you must call this every time to bring
-  // the content view to the front, otherwise the content view will not be
-  // visible and covered by the pip host view.
-  if (_pipViewController) {
-    [_pipViewController.view bringSubviewToFront:_contentView];
-  }
-#else
-  // TODO @sylar: check if this is the best way to do this, what will happen if
-  // we have multiple windows? what if the root view controller is not a
-  // UIViewController?
-  UIWindow *window = [[UIApplication sharedApplication] windows].firstObject;
+  UIWindow *window = [self activeKeyWindow];
   if (window) {
     UIViewController *rootViewController = window.rootViewController;
     UIView *superview = rootViewController.view.superview;
     [self insertContentViewIfNeeded:superview];
   }
-#endif
 
   _isPipActived = YES;
   [_pipStateDelegate pipStateChanged:PipStateStarted error:nil];

--- a/ios/pip/Sources/pip/PipPlugin.m
+++ b/ios/pip/Sources/pip/PipPlugin.m
@@ -31,45 +31,52 @@
   } else if ([@"isActived" isEqualToString:call.method]) {
     result([NSNumber numberWithBool:[self.pipController isActived]]);
   } else if ([@"setup" isEqualToString:call.method]) {
+    if (![call.arguments isKindOfClass:[NSDictionary class]]) {
+      result(@NO);
+      return;
+    }
+
+    NSDictionary *arguments = (NSDictionary *)call.arguments;
+
     @autoreleasepool {
       // new options
       PipOptions *options = [[PipOptions alloc] init];
 
       // source content view
-      if ([call.arguments objectForKey:@"sourceContentView"] &&
-          [[call.arguments objectForKey:@"sourceContentView"]
+      if ([arguments objectForKey:@"sourceContentView"] &&
+          [[arguments objectForKey:@"sourceContentView"]
               isKindOfClass:[NSNumber class]]) {
-        options.sourceContentView = (__bridge UIView *)[[call.arguments
+        options.sourceContentView = (__bridge UIView *)[[arguments
             objectForKey:@"sourceContentView"] pointerValue];
       }
 
       // content view
-      if ([call.arguments objectForKey:@"contentView"] &&
-          [[call.arguments objectForKey:@"contentView"]
+      if ([arguments objectForKey:@"contentView"] &&
+          [[arguments objectForKey:@"contentView"]
               isKindOfClass:[NSNumber class]]) {
-        options.contentView = (__bridge UIView *)[[call.arguments
+        options.contentView = (__bridge UIView *)[[arguments
             objectForKey:@"contentView"] pointerValue];
       }
 
       // auto enter
-      if ([call.arguments objectForKey:@"autoEnterEnabled"]) {
+      if ([arguments objectForKey:@"autoEnterEnabled"]) {
         options.autoEnterEnabled =
-            [[call.arguments objectForKey:@"autoEnterEnabled"] boolValue];
+            [[arguments objectForKey:@"autoEnterEnabled"] boolValue];
       }
 
       // preferred content size
-      if ([call.arguments objectForKey:@"preferredContentWidth"] &&
-          [call.arguments objectForKey:@"preferredContentHeight"]) {
+      if ([arguments objectForKey:@"preferredContentWidth"] &&
+          [arguments objectForKey:@"preferredContentHeight"]) {
         options.preferredContentSize = CGSizeMake(
-            [[call.arguments objectForKey:@"preferredContentWidth"] floatValue],
-            [[call.arguments objectForKey:@"preferredContentHeight"]
+            [[arguments objectForKey:@"preferredContentWidth"] floatValue],
+            [[arguments objectForKey:@"preferredContentHeight"]
                 floatValue]);
       }
 
       // control style
-      if ([call.arguments objectForKey:@"controlStyle"]) {
+      if ([arguments objectForKey:@"controlStyle"]) {
         options.controlStyle =
-            [[call.arguments objectForKey:@"controlStyle"] intValue];
+            [[arguments objectForKey:@"controlStyle"] intValue];
       } else {
         // default to show all system controls
         options.controlStyle = 0;

--- a/ios/pip/Sources/pip/include/pip/PipController.h
+++ b/ios/pip/Sources/pip/include/pip/PipController.h
@@ -43,13 +43,13 @@ typedef NS_ENUM(NSInteger, PipState) {
  * @abstract The source content view for pip, set to nil will use the root
  * view of the application as the source content view.
  */
-@property(nonatomic, assign) UIView *_Nullable sourceContentView;
+@property(nonatomic, nullable, weak) UIView *sourceContentView;
 
 /**
  * @property contentView
  * @abstract The content view for pip.
  */
-@property(nonatomic, assign) UIView *_Nullable contentView;
+@property(nonatomic, nullable, weak) UIView *contentView;
 
 /**
  * @property autoEnterEnabled

--- a/lib/pip_platform_interface.dart
+++ b/lib/pip_platform_interface.dart
@@ -84,9 +84,9 @@ class PipOptions {
   /// The control style of the content view.
   ///
   /// 0: default show all system controls
-  /// 1: hide forward and backward button
-  /// 2: hide play pause button and the progress bar including forward and backward button (recommended)
-  /// 3: hide all system controls including the close and restore button
+  /// 1: request documented linear playback behavior
+  /// 2: hide play/pause button and progress bar using private iOS API
+  /// 3: hide all system controls using private iOS API
   final int? controlStyle;
 
   /// Convert the options to a dictionary.

--- a/test/pip_method_channel_test.dart
+++ b/test/pip_method_channel_test.dart
@@ -235,6 +235,19 @@ void main() {
     });
   });
 
+  test('allows iOS private control styles for backward compatibility', () {
+    withTargetPlatform(TargetPlatform.iOS, () {
+      expect(
+        const PipOptions(controlStyle: 2).toDictionary(),
+        containsPair('controlStyle', 2),
+      );
+      expect(
+        const PipOptions(controlStyle: 3).toDictionary(),
+        containsPair('controlStyle', 3),
+      );
+    });
+  });
+
   test('ignores invalid options for inactive platforms', () {
     withTargetPlatform(TargetPlatform.iOS, () {
       expect(


### PR DESCRIPTION
## Summary

This redoes PR 05 for iOS lifecycle hardening while explicitly preserving the private iOS `controlStyle` path.

## What changed

- harden iOS PiP controller lifecycle around main-thread execution
- switch iOS-host-owned view references from `assign` to `weak`
- clear restored constraint snapshots after content view restoration
- use a more robust active key window lookup for iOS scene setups
- preserve private `controlsStyle` KVC access for `controlStyle` 2/3 and add reset behavior
- reject non-dictionary iOS `setup` arguments instead of assuming map-shaped input
- update README and Dart docs to describe the private iOS control-style behavior and risk
- add Dart regression coverage for preserving iOS private control styles
- add iOS RunnerTests coverage for weak property semantics and private control-style apply/reset behavior

## Why

The original industrialization plan for PR 05 assumed the private iOS control-style path should be removed. The current requirement is the opposite: keep it, because there is no acceptable replacement right now, while still tightening iOS lifecycle safety.

## Validation

- `flutter test`
- `flutter analyze`
- `cd example && flutter build ios --simulator`
- `xcodebuild test -project example/ios/Runner.xcodeproj -scheme Runner -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.1' -only-testing:RunnerTests`

## Notes

- `controlStyle` values `2` and `3` still rely on private AVKit behavior and remain compatibility / App Store review risks.
- Untracked planning docs under `docs/` were intentionally left out of this PR because they are not part of the code change scope.
