### PR TITLE
[codex] add release metadata consistency checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run package checks
         run: ./scripts/check.sh
 
+      - name: Check release metadata
+        run: ./scripts/check_release_ready.sh
+
       - name: Check Swift Package Manager support
         run: ./scripts/check_spm.sh
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Run package checks
         run: ./scripts/check.sh
 
+      - name: Check release metadata
+        run: ./scripts/check_release_ready.sh
+
       - name: Publish dry run
         if: inputs.dry_run
         run: ./scripts/publish.sh dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Run package checks
         run: ./scripts/check.sh
 
+      - name: Check release metadata
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: ./scripts/check_release_ready.sh
+
       - name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pubignore
+++ b/.pubignore
@@ -1,4 +1,5 @@
 test/
+docs/
 
 # Local build and tool state should never be part of the published package.
 .dart_tool/

--- a/ios/pip.podspec
+++ b/ios/pip.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'pip'
-  s.version          = '0.0.1'
+  s.version          = '0.0.3'
   s.summary          = 'A plugin for Picture in Picture.'
   s.description      = <<-DESC
 A plugin for Picture in Picture.

--- a/scripts/check_release_ready.sh
+++ b/scripts/check_release_ready.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pubspec_line="$(grep -E '^version:\s*' pubspec.yaml | head -n 1 || true)"
+if [[ -z "$pubspec_line" ]]; then
+  echo "pubspec.yaml version not found" >&2
+  exit 1
+fi
+version="${pubspec_line#version:}"
+version="${version//[[:space:]]/}"
+
+podspec_line="$(grep -E "s\.version\s*=\s*'[^']+'" ios/pip.podspec | head -n 1 || true)"
+if [[ -z "$podspec_line" ]]; then
+  echo "ios/pip.podspec version not found" >&2
+  exit 1
+fi
+podspec_version="$(printf '%s\n' "$podspec_line" | sed -E "s/.*'([^']+)'.*/\1/")"
+
+if [[ "$version" != "$podspec_version" ]]; then
+  echo "Version mismatch: pubspec.yaml has $version, ios/pip.podspec has $podspec_version" >&2
+  exit 1
+fi
+
+if ! grep -Eq "^# $version$|^## $version$" CHANGELOG.md; then
+  echo "CHANGELOG.md does not contain an entry for $version" >&2
+  exit 1
+fi
+
+expected_version="${RELEASE_VERSION:-}"
+if [[ -z "$expected_version" && "${GITHUB_REF:-}" == refs/tags/* ]]; then
+  tag="${GITHUB_REF#refs/tags/}"
+  expected_version="${tag#v}"
+fi
+
+if [[ -n "$expected_version" && "$expected_version" != "$version" ]]; then
+  echo "Release version $expected_version does not match pubspec version $version" >&2
+  exit 1
+fi

--- a/test/check_release_ready_test.sh
+++ b/test/check_release_ready_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cp "$repo_root/pubspec.yaml" "$tmp_dir/pubspec.yaml"
+mkdir -p "$tmp_dir/ios"
+cp "$repo_root/ios/pip.podspec" "$tmp_dir/ios/pip.podspec"
+cp "$repo_root/CHANGELOG.md" "$tmp_dir/CHANGELOG.md"
+cp "$repo_root/scripts/check_release_ready.sh" "$tmp_dir/check_release_ready.sh"
+chmod +x "$tmp_dir/check_release_ready.sh"
+
+(
+  cd "$tmp_dir"
+  ./check_release_ready.sh
+)
+
+if (
+  cd "$tmp_dir"
+  RELEASE_VERSION="9.9.9" ./check_release_ready.sh >/dev/null 2>&1
+); then
+  echo "expected RELEASE_VERSION mismatch to fail" >&2
+  exit 1
+fi
+
+echo "check_release_ready.sh tests passed"


### PR DESCRIPTION
## Summary

Add a release metadata consistency checker and wire it into CI and release workflows.

## What changed

- add `scripts/check_release_ready.sh` to verify:
  - `pubspec.yaml` version matches `ios/pip.podspec`
  - `CHANGELOG.md` contains the current version
  - tag / release input version matches package version when provided
- add a small shell regression test for the checker
- run the checker in `check.yml`, `publish.yml`, and `release.yml`
- pass `workflow_dispatch` release input version into the release metadata check
- align `ios/pip.podspec` version from `0.0.1` to `0.0.3`
- exclude internal `docs/` planning files from pub package publishing via `.pubignore`

## Why

The repository could previously drift between `pubspec.yaml`, `ios/pip.podspec`, changelog entries, and manually entered GitHub release versions. This PR adds an explicit gate so release metadata mismatches fail before publish / release steps continue.

## Validation

- `bash test/check_release_ready_test.sh`
- `./scripts/check_release_ready.sh`
- `RELEASE_VERSION=0.0.3 ./scripts/check_release_ready.sh`
- `RELEASE_VERSION=0.0.4 ./scripts/check_release_ready.sh` (expected failure)
- `./scripts/check.sh`

## Notes

- `./scripts/check.sh` now passes cleanly after committing this PR; before commit, `dart pub publish --dry-run` warned about the modified `ios/pip.podspec`, which is expected for an in-progress metadata PR.
- Internal planning docs under `docs/` are intentionally excluded from the published package and not part of the runtime package surface.
