### PR TITLE
[codex] strengthen Dart package checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Run package checks
         run: ./scripts/check.sh
 
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+          if-no-files-found: ignore
+
       - name: Check release metadata
         run: ./scripts/check_release_ready.sh
 

--- a/.pubignore
+++ b/.pubignore
@@ -4,6 +4,7 @@ docs/
 # Local build and tool state should never be part of the published package.
 .dart_tool/
 build/
+coverage/
 .flutter-plugins
 .flutter-plugins-dependencies
 .packages

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,3 +2,9 @@ include: package:flutter_lints/flutter.yaml
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options
+
+linter:
+  rules:
+    avoid_print: true
+    depend_on_referenced_packages: true
+    unawaited_futures: true

--- a/example/packages/native_plugin/example/integration_test/plugin_integration_test.dart
+++ b/example/packages/native_plugin/example/integration_test/plugin_integration_test.dart
@@ -6,7 +6,6 @@
 // For more information about Flutter integration tests, please see
 // https://flutter.dev/to/integration-testing
 
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 

--- a/example/packages/native_plugin/example/lib/main.dart
+++ b/example/packages/native_plugin/example/lib/main.dart
@@ -32,7 +32,8 @@ class _MyAppState extends State<MyApp> {
     // We also handle the message potentially returning null.
     try {
       platformVersion =
-          await _nativePlugin.getPlatformVersion() ?? 'Unknown platform version';
+          await _nativePlugin.getPlatformVersion() ??
+          'Unknown platform version';
     } on PlatformException {
       platformVersion = 'Failed to get platform version.';
     }
@@ -51,12 +52,8 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Plugin example app'),
-        ),
-        body: Center(
-          child: Text('Running on: $_platformVersion\n'),
-        ),
+        appBar: AppBar(title: const Text('Plugin example app')),
+        body: Center(child: Text('Running on: $_platformVersion\n')),
       ),
     );
   }

--- a/example/packages/native_plugin/example/test/widget_test.dart
+++ b/example/packages/native_plugin/example/test/widget_test.dart
@@ -19,8 +19,8 @@ void main() {
     // Verify that platform version is retrieved.
     expect(
       find.byWidgetPredicate(
-        (Widget widget) => widget is Text &&
-                           widget.data!.startsWith('Running on:'),
+        (Widget widget) =>
+            widget is Text && widget.data!.startsWith('Running on:'),
       ),
       findsOneWidget,
     );

--- a/example/packages/native_plugin/lib/native_plugin.dart
+++ b/example/packages/native_plugin/lib/native_plugin.dart
@@ -1,4 +1,3 @@
-
 import 'native_plugin_platform_interface.dart';
 
 class NativePlugin {

--- a/example/packages/native_plugin/lib/native_plugin_method_channel.dart
+++ b/example/packages/native_plugin/lib/native_plugin_method_channel.dart
@@ -11,13 +11,17 @@ class MethodChannelNativePlugin extends NativePluginPlatform {
 
   @override
   Future<String?> getPlatformVersion() async {
-    final version = await methodChannel.invokeMethod<String>('getPlatformVersion');
+    final version = await methodChannel.invokeMethod<String>(
+      'getPlatformVersion',
+    );
     return version;
   }
 
   @override
   Future<int> createPipContentView() async {
-    final viewId = await methodChannel.invokeMethod<int>('createPipContentView');
+    final viewId = await methodChannel.invokeMethod<int>(
+      'createPipContentView',
+    );
     return viewId ?? 0;
   }
 

--- a/example/packages/native_plugin/lib/native_plugin_platform_interface.dart
+++ b/example/packages/native_plugin/lib/native_plugin_platform_interface.dart
@@ -28,10 +28,14 @@ abstract class NativePluginPlatform extends PlatformInterface {
   }
 
   Future<int> createPipContentView() {
-    throw UnimplementedError('createPipContentView() has not been implemented.');
+    throw UnimplementedError(
+      'createPipContentView() has not been implemented.',
+    );
   }
 
   Future<void> disposePipContentView(int viewId) {
-    throw UnimplementedError('disposePipContentView() has not been implemented.');
+    throw UnimplementedError(
+      'disposePipContentView() has not been implemented.',
+    );
   }
 }

--- a/example/packages/native_plugin/test/native_plugin_method_channel_test.dart
+++ b/example/packages/native_plugin/test/native_plugin_method_channel_test.dart
@@ -9,16 +9,15 @@ void main() {
   const MethodChannel channel = MethodChannel('native_plugin');
 
   setUp(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
-      channel,
-      (MethodCall methodCall) async {
-        return '42';
-      },
-    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+          return '42';
+        });
   });
 
   tearDown(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
   });
 
   test('getPlatformVersion', () async {

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -18,8 +18,8 @@ void main() {
     // Verify that platform version is retrieved.
     expect(
       find.byWidgetPredicate(
-        (Widget widget) => widget is Text &&
-                           widget.data!.startsWith('Running on:'),
+        (Widget widget) =>
+            widget is Text && widget.data!.startsWith('Running on:'),
       ),
       findsOneWidget,
     );

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,7 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-flutter pub get
-flutter analyze
-flutter test
-dart pub publish --dry-run
+if command -v flutter >/dev/null 2>&1; then
+  flutter_bin="$(command -v flutter)"
+  flutter_cmd=("$flutter_bin")
+elif command -v fvm >/dev/null 2>&1; then
+  flutter_cmd=(fvm flutter)
+elif [[ -x "/Users/sylar/fvm/versions/stable/bin/flutter" ]]; then
+  flutter_cmd=("/Users/sylar/fvm/versions/stable/bin/flutter")
+else
+  echo "flutter executable not found" >&2
+  exit 127
+fi
+
+if command -v dart >/dev/null 2>&1; then
+  dart_cmd=(dart)
+elif [[ -n "${flutter_bin:-}" && -x "$(dirname "$flutter_bin")/dart" ]]; then
+  dart_cmd=("$(dirname "$flutter_bin")/dart")
+elif [[ "${flutter_cmd[0]}" == "fvm" ]]; then
+  dart_cmd=(fvm dart)
+elif [[ "${flutter_cmd[0]}" == "/Users/sylar/fvm/versions/stable/bin/flutter" ]]; then
+  dart_cmd=("/Users/sylar/fvm/versions/stable/bin/dart")
+else
+  echo "dart executable not found" >&2
+  exit 127
+fi
+
+"${flutter_cmd[@]}" pub get
+"${dart_cmd[@]}" format --set-exit-if-changed .
+"${flutter_cmd[@]}" analyze --fatal-infos --fatal-warnings
+"${flutter_cmd[@]}" test --coverage
+"${dart_cmd[@]}" pub publish --dry-run


### PR DESCRIPTION
## Summary

Strengthen Dart package checks by enforcing formatting, stricter analyzer behavior, coverage generation, and CI coverage artifact upload.

## What changed

- update `scripts/check.sh` to run:
  - `flutter pub get`
  - `dart format --set-exit-if-changed .`
  - `flutter analyze --fatal-infos --fatal-warnings`
  - `flutter test --coverage`
  - `dart pub publish --dry-run`
- make `check.sh` self-bootstrap Flutter/Dart resolution for local environments where `flutter` or `dart` are not both directly on `PATH`
- tighten root `analysis_options.yaml` with:
  - `avoid_print`
  - `depend_on_referenced_packages`
  - `unawaited_futures`
- upload `coverage/lcov.info` in `.github/workflows/check.yml`
- exclude generated `coverage/` from pub package publishing
- include the mechanical `dart format` updates required by the stricter check script

## Why

The package checks previously allowed unformatted code, did not collect coverage, and did not fail on analyzer infos/warnings. This PR turns those checks into a stricter gate so regressions are caught before later CI and release steps.

## Validation

- `./scripts/check.sh`
- verified `dart pub publish --dry-run` no longer includes `coverage/lcov.info`
- verified the only pre-commit `dry-run` failure mode was dirty git state; after commit the script reaches `Package has 0 warnings`

## Notes

- The `example/packages/native_plugin/**` and `example/test/widget_test.dart` diffs are formatting-only changes caused by `dart format --set-exit-if-changed .`.
- Untracked local directories like `docs/`, `coverage/`, and `.codex/` were intentionally left out of this PR.
