### PR TITLE
[codex] fix iOS PiP content view reparenting lifetime

### DIFF
--- a/example/ios/RunnerTests/RunnerTests.swift
+++ b/example/ios/RunnerTests/RunnerTests.swift
@@ -18,6 +18,14 @@ private final class FakePictureInPictureController: NSObject {
   }
 }
 
+private final class DeinitAwareView: UIView {
+  var onDeinit: (() -> Void)?
+
+  deinit {
+    onDeinit?()
+  }
+}
+
 final class RunnerTests: XCTestCase {
   func testPipOptionsViewPropertiesUseWeakReferences() {
     guard let pipOptionsClass = NSClassFromString("PipOptions") else {
@@ -102,6 +110,65 @@ final class RunnerTests: XCTestCase {
     XCTAssertEqual(fakePictureInPictureController.appliedControlStyles.last, 0)
   }
 
+  func testPipControllerRestoresContentViewAfterMovingBetweenParents() {
+    guard let pipControllerClass = NSClassFromString("PipController") as? NSObject.Type else {
+      return XCTFail("PipController class not found at runtime")
+    }
+
+    let controller = pipControllerClass.init()
+    let originalParent = UIView(frame: CGRect(x: 0, y: 0, width: 120, height: 120))
+    let newParent = UIView(frame: CGRect(x: 0, y: 0, width: 240, height: 240))
+
+    var deinitCalled = false
+    weak var weakManagedContentView: DeinitAwareView?
+
+    func installManagedContentView() {
+      let managedContentView = DeinitAwareView(frame: CGRect(x: 10, y: 20, width: 30, height: 40))
+      managedContentView.translatesAutoresizingMaskIntoConstraints = false
+      managedContentView.onDeinit = {
+        deinitCalled = true
+      }
+
+      weakManagedContentView = managedContentView
+      originalParent.addSubview(managedContentView)
+      controller.setValue(managedContentView, forKey: "contentView")
+    }
+
+    installManagedContentView()
+    guard weakManagedContentView != nil else {
+      return XCTFail("Failed to create content view")
+    }
+
+    invokeVoidSelector(
+      named: "insertContentViewIfNeeded:",
+      on: controller,
+      object: newParent,
+      owner: pipControllerClass
+    )
+
+    guard let insertedContentView = weakManagedContentView else {
+      return XCTFail("contentView should stay alive after being inserted into the new parent")
+    }
+    XCTAssertTrue(newParent.subviews.contains(insertedContentView))
+    XCTAssertFalse(originalParent.subviews.contains(insertedContentView))
+    XCTAssertFalse(deinitCalled, "contentView should stay alive while it is managed by a parent view")
+
+    invokeVoidSelector(
+      named: "restoreContentViewIfNeeded",
+      on: controller,
+      owner: pipControllerClass
+    )
+
+    guard let restoredContentView = weakManagedContentView else {
+      return XCTFail("contentView should still be alive after restoration")
+    }
+
+    XCTAssertTrue(originalParent.subviews.contains(restoredContentView))
+    XCTAssertFalse(newParent.subviews.contains(restoredContentView))
+    XCTAssertEqual(restoredContentView.frame, CGRect(x: 10, y: 20, width: 30, height: 40))
+    XCTAssertFalse(deinitCalled, "contentView should remain alive after restoration")
+  }
+
   private func assertPropertyAttributes(
     of cls: AnyClass,
     named propertyName: String,
@@ -132,5 +199,38 @@ final class RunnerTests: XCTestCase {
       file: file,
       line: line
     )
+  }
+
+  private func invokeVoidSelector(
+    named selectorName: String,
+    on object: AnyObject,
+    owner cls: AnyClass
+  ) {
+    let selector = NSSelectorFromString(selectorName)
+    guard let method = class_getInstanceMethod(cls, selector) else {
+      return XCTFail("Expected selector \(selectorName) on \(NSStringFromClass(cls))")
+    }
+
+    typealias VoidMethod = @convention(c) (AnyObject, Selector) -> Void
+    let implementation = method_getImplementation(method)
+    let function = unsafeBitCast(implementation, to: VoidMethod.self)
+    function(object, selector)
+  }
+
+  private func invokeVoidSelector(
+    named selectorName: String,
+    on object: AnyObject,
+    object argument: AnyObject,
+    owner cls: AnyClass
+  ) {
+    let selector = NSSelectorFromString(selectorName)
+    guard let method = class_getInstanceMethod(cls, selector) else {
+      return XCTFail("Expected selector \(selectorName) on \(NSStringFromClass(cls))")
+    }
+
+    typealias ObjectMethod = @convention(c) (AnyObject, Selector, AnyObject) -> Void
+    let implementation = method_getImplementation(method)
+    let function = unsafeBitCast(implementation, to: ObjectMethod.self)
+    function(object, selector, argument)
   }
 }

--- a/ios/pip/Sources/pip/PipController.m
+++ b/ios/pip/Sources/pip/PipController.m
@@ -366,15 +366,17 @@
 // you should addtionaly call bringSubViewToFront in
 // pictureInPictureControllerDidStartPictureInPicture.
 - (void)insertContentViewIfNeeded:(UIView *)newParentView {
+  UIView *contentView = _contentView;
+
   // if the content view is not set or the new parent view is not set, just
   // return
-  if (_contentView == nil || newParentView == nil) {
+  if (contentView == nil || newParentView == nil) {
     PIP_LOG(@"insertContentViewIfNeeded: contentView or newParentView is nil");
     return;
   }
 
   // if the content view is already in the new parent view, just return
-  if ([newParentView.subviews containsObject:_contentView]) {
+  if ([newParentView.subviews containsObject:contentView]) {
     PIP_LOG(@"insertContentViewIfNeeded: contentView is already in the new "
             @"parent view");
     return;
@@ -382,21 +384,24 @@
 
   // save the original content view properties
   [self clearContentViewRestoreSnapshot];
-  _contentViewOriginalParentView = _contentView.superview;
-  if (_contentViewOriginalParentView != nil) {
+  UIView *originalParentView = contentView.superview;
+  _contentViewOriginalParentView = originalParentView;
+  if (originalParentView != nil) {
+    NSArray *contentViewConstraints = contentView.constraints ?: @[];
+    NSArray *originalParentConstraints = originalParentView.constraints ?: @[];
+
     _contentViewOriginalIndex =
-        [_contentViewOriginalParentView.subviews indexOfObject:_contentView];
-    _contentViewOriginalFrame = _contentView.frame;
+        [originalParentView.subviews indexOfObject:contentView];
+    _contentViewOriginalFrame = contentView.frame;
     _contentViewOriginalTranslatesAutoresizingMaskIntoConstraints =
-        _contentView.translatesAutoresizingMaskIntoConstraints;
+        contentView.translatesAutoresizingMaskIntoConstraints;
     [_contentViewOriginalConstraints
-        addObjectsFromArray:_contentView.constraints.mutableCopy];
+        addObjectsFromArray:contentViewConstraints];
     [_contentViewOriginalParentViewConstraints
-        addObjectsFromArray:_contentViewOriginalParentView.constraints
-                                .mutableCopy];
+        addObjectsFromArray:originalParentConstraints];
 
     // remove the content view from the original parent view
-    [_contentView removeFromSuperview];
+    [contentView removeFromSuperview];
 
     PIP_LOG(
         @"insertContentViewIfNeeded: contentView is removed from the original "
@@ -404,7 +409,7 @@
   }
 
   // add the content view to the new parent view
-  [newParentView insertSubview:_contentView
+  [newParentView insertSubview:contentView
                        atIndex:newParentView.subviews.count];
 
   // no need to bring the content view to the front, because the content view
@@ -413,10 +418,10 @@
   // [newParentView bringSubviewToFront:_contentView];
 
   // update the content view constraints
-  _contentView.translatesAutoresizingMaskIntoConstraints = YES;
-  _contentView.autoresizingMask =
+  contentView.translatesAutoresizingMaskIntoConstraints = YES;
+  contentView.autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  _contentView.frame = newParentView.frame;
+  contentView.frame = newParentView.frame;
 
   // It seems like no need to do so.
   // [newParentView addConstraints:@[
@@ -434,10 +439,13 @@
 }
 
 - (void)restoreContentViewIfNeeded {
+  UIView *contentView = _contentView;
+  UIView *originalParentView = _contentViewOriginalParentView;
+
   // only restore the content view if it is not nil and the original parent
   // view is not nil and the content view is already in the original parent view
-  if (_contentView == nil || _contentViewOriginalParentView == nil ||
-      [_contentViewOriginalParentView.subviews containsObject:_contentView]) {
+  if (contentView == nil || originalParentView == nil ||
+      [originalParentView.subviews containsObject:contentView]) {
     PIP_LOG(
         @"restoreContentViewIfNeeded: _contentViewOriginalParentView is nil or "
         @"contentView is already in the original parent view");
@@ -445,16 +453,16 @@
     return;
   }
 
-  [_contentView removeFromSuperview];
+  [contentView removeFromSuperview];
   PIP_LOG(
       @"restoreContentViewIfNeeded: contentView is removed from the original "
       @"parent view");
 
   // in case that the subviews of _contentViewOriginalParentView has been
   // changed, we need to get the real index of the content view.
-  NSUInteger trueIndex = MIN(_contentViewOriginalParentView.subviews.count,
+  NSUInteger trueIndex = MIN(originalParentView.subviews.count,
                              _contentViewOriginalIndex);
-  [_contentViewOriginalParentView insertSubview:_contentView atIndex:trueIndex];
+  [originalParentView insertSubview:contentView atIndex:trueIndex];
 
   PIP_LOG(@"restoreContentViewIfNeeded: contentView is added to the original "
           @"parent view "
@@ -462,21 +470,30 @@
           trueIndex);
 
   // restore the original frame
-  _contentView.frame = _contentViewOriginalFrame;
+  contentView.frame = _contentViewOriginalFrame;
 
   // restore the original constraints
-  [_contentView removeConstraints:_contentView.constraints.copy];
-  [_contentView addConstraints:_contentViewOriginalConstraints];
+  NSArray *currentContentConstraints = contentView.constraints ?: @[];
+  if (currentContentConstraints.count > 0) {
+    [contentView removeConstraints:currentContentConstraints];
+  }
+  if (_contentViewOriginalConstraints.count > 0) {
+    [contentView addConstraints:_contentViewOriginalConstraints];
+  }
 
   // restore the original translatesAutoresizingMaskIntoConstraints
-  _contentView.translatesAutoresizingMaskIntoConstraints =
+  contentView.translatesAutoresizingMaskIntoConstraints =
       _contentViewOriginalTranslatesAutoresizingMaskIntoConstraints;
 
   // restore the original parent view
-  [_contentViewOriginalParentView
-      removeConstraints:_contentViewOriginalParentView.constraints.copy];
-  [_contentViewOriginalParentView
-      addConstraints:_contentViewOriginalParentViewConstraints];
+  NSArray *currentOriginalParentConstraints = originalParentView.constraints ?: @[];
+  if (currentOriginalParentConstraints.count > 0) {
+    [originalParentView removeConstraints:currentOriginalParentConstraints];
+  }
+  if (_contentViewOriginalParentViewConstraints.count > 0) {
+    [originalParentView
+        addConstraints:_contentViewOriginalParentViewConstraints];
+  }
 
   [self clearContentViewRestoreSnapshot];
 }


### PR DESCRIPTION
## Summary

This PR fixes an iOS PiP lifecycle bug where `contentView` and its original parent could be lost while the plugin reparents the view between container hierarchies.

## What changed

- keep strong local references to `contentView` and its original parent while `insertContentViewIfNeeded:` and `restoreContentViewIfNeeded` move the view between superviews
- tighten constraint snapshot/restore handling so we only pass concrete `NSArray` values back into UIKit APIs
- add an iOS regression test that exercises the reparent-and-restore path without an extra caller-owned strong reference

## Root cause

PR #28 intentionally changed the stored view references from `assign` to `weak`. That fixed ownership semantics overall, but it also created a short lifetime window during `removeFromSuperview` where the plugin could temporarily become the only holder of those views while still storing them weakly.

## Validation

- `xcodebuild test -workspace Runner.xcworkspace -scheme Runner -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:RunnerTests`
- `xcodebuild test -workspace Runner.xcworkspace -scheme Runner -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:RunnerTests/RunnerTests/testPipControllerRestoresContentViewAfterMovingBetweenParents`
- `fvm flutter test test/pip_method_channel_test.dart`
