### PR TITLE
[codex] stop running Check on branch pushes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,6 @@ name: Check
 
 on:
   pull_request:
-  push:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Stop running the `Check` workflow on branch `push` events so PR branches only consume CI once through the `pull_request` trigger.

## What changed

- remove the `push` trigger from `.github/workflows/check.yml`
- keep `pull_request` and `workflow_dispatch`

## Why

The previous workflow configuration ran the same three check jobs twice for every PR update:
- once for the branch `push`
- once for the PR sync event

That duplicates runtime and CI resources without adding signal, because this repository does not need a separate post-push or post-merge `Check` run.

## Validation

Reviewed the workflow trigger change directly in `.github/workflows/check.yml`.

## Notes

- This change intentionally means `Check` will no longer run on direct pushes to `main`.
- Local untracked `.codex/`, `coverage/`, and `docs/` directories are intentionally left out of this PR.
