### PR TITLE
[codex] automate GitHub release and pub.dev publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,14 @@
 name: Publish
 
 on:
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: Run pub publish in dry-run mode
-        required: true
-        default: true
-        type: boolean
+  push:
+    tags:
+      - 'v*.*.*'
 
 jobs:
   publish:
     runs-on: macos-latest
+    environment: pub.dev
     permissions:
       contents: read
       id-token: write
@@ -26,16 +23,14 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Set up Dart for pub.dev publishing
+        uses: dart-lang/setup-dart@v1
+
       - name: Run package checks
         run: ./scripts/check.sh
 
       - name: Check release metadata
         run: ./scripts/check_release_ready.sh
 
-      - name: Publish dry run
-        if: inputs.dry_run
-        run: ./scripts/publish.sh dry-run
-
       - name: Publish to pub.dev
-        if: ${{ !inputs.dry_run }}
         run: ./scripts/publish.sh publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,14 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: write
+      models: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.ref_name }}
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -35,13 +37,22 @@ jobs:
       - name: Install release tooling
         run: npm ci
 
+      - name: Generate release notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_MODELS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: ./scripts/generate_release_notes.sh ${{ inputs.version }} ${{ github.repository }} ${{ github.ref_name }} .release-notes.md
+
       - name: Run package checks
         run: ./scripts/check.sh
 
-      - name: Check release metadata
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: ./scripts/check_release_ready.sh
+      - name: Check Swift Package Manager support
+        run: ./scripts/check_spm.sh
+
+      - name: Check Android deprecated API usage
+        run: ./scripts/check_android_deprecated_api.sh
 
       - name: Create GitHub release
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ migrate_working_dir/
 build/
 .build/
 .swiftpm/
+coverage/
+node_modules/
+.codex/
+/docs/superpowers/
+.release-notes.md
 
 # FVM Version Cache
 .fvm/

--- a/.pubignore
+++ b/.pubignore
@@ -8,6 +8,11 @@ coverage/
 .flutter-plugins
 .flutter-plugins-dependencies
 .packages
+node_modules/
+package.json
+package-lock.json
+.release-it.json
+.release-notes.md
 
 # Generated example app state.
 example/.dart_tool/

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,12 +1,34 @@
 {
+  "hooks": {
+    "after:bump": "./scripts/prepare_release.sh ${version}",
+    "before:git:release": "RELEASE_VERSION=${version} ./scripts/check_release_ready.sh"
+  },
+  "plugins": {
+    "@release-it/bumper": {
+      "in": {
+        "file": "pubspec.yaml",
+        "path": "version"
+      },
+      "out": [
+        {
+          "file": "pubspec.yaml",
+          "path": "version"
+        },
+        {
+          "file": "ios/pip.podspec",
+          "type": "text/plain"
+        }
+      ]
+    }
+  },
   "git": {
     "commitMessage": "chore: release ${version}",
-    "tagName": "v${version}"
+    "tagName": "v${version}",
+    "requireUpstream": false
   },
   "github": {
-    "release": true
+    "release": true,
+    "releaseNotes": "cat .release-notes.md"
   },
-  "npm": {
-    "publish": false
-  }
+  "npm": false
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,25 @@ flutter pub get
 ./scripts/check_android_deprecated_api.sh
 ```
 
+## Release Automation
+
+This repository uses a two-stage release flow:
+
+1. Trigger the `Release` GitHub Actions workflow with a version such as `0.0.4`.
+2. The workflow generates release notes, runs checks, bumps release metadata,
+   creates the release commit and tag, and publishes a GitHub Release.
+3. The pushed tag automatically triggers the `Publish` workflow, which publishes
+   the package to `pub.dev`.
+
+Repository configuration requirements:
+
+- `GITHUB_TOKEN` must be allowed to create releases and push tags.
+- The `Release` workflow requires `models: read` so GitHub Models can summarize
+  the generated release notes. If GitHub Models is unavailable, the workflow
+  falls back to the generated GitHub release notes without the AI summary.
+- The `Publish` workflow requires the `pub.dev` environment to be configured
+  for Dart automated publishing with GitHub Actions OIDC.
+
 Run Android and iOS example builds when changing native code:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -211,3 +211,14 @@ The example demonstrates:
   pass into `PipOptions`.
 - On Android, `useExternalStateMonitor` exists because some host activity paths
   do not naturally forward PiP state changes back to Flutter.
+
+## Release Process
+
+Maintainers publish new versions through GitHub Actions:
+
+- Run the `Release` workflow with the target version number.
+- The workflow generates GitHub release notes, optionally prepends a GitHub
+  Models summary, updates release metadata, and creates the GitHub Release.
+- The resulting tag automatically triggers the `Publish` workflow for `pub.dev`.
+
+The `Publish` workflow depends on Dart automated publishing for GitHub Actions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,11 @@
 {
-  "name": "issue-9-ci-cd",
+  "name": "pip",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "devDependencies": {
+        "@release-it/bumper": "^7.0.6",
         "release-it": "^18.0.0"
       }
     },
@@ -31,6 +32,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@decimalturn/toml-patch": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@decimalturn/toml-patch/-/toml-patch-1.3.0.tgz",
+      "integrity": "sha512-lnnGHUF8RhnPq0XiOenQCv0O6TO840bofShFrIr+Xu87x1Rm3bozgaCDQz6eTErO9rYf7YXCuK7ZHz65BtBwsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@iarna/toml": {
@@ -673,6 +684,60 @@
         "node": ">=12"
       }
     },
+    "node_modules/@release-it/bumper": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@release-it/bumper/-/bumper-7.0.6.tgz",
+      "integrity": "sha512-vzKrEGPac/yim5WUjMmIQ9k+n3NlWHYraUIlLkHna2Ka0+zmmB1peW8POMjA6Fb7TwcIsNMuoXj2wLc8NFzgRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@decimalturn/toml-patch": "^1.3.0",
+        "@iarna/toml": "^3.0.0",
+        "cheerio": "^1.2.0",
+        "detect-indent": "7.0.2",
+        "fast-glob": "^3.3.3",
+        "ini": "^6.0.0",
+        "js-yaml": "^4.1.1",
+        "lodash-es": "^4.18.1",
+        "semver": "^7.8.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "release-it": "^18.0.0 || ^19.0.0 || ^20.0.0"
+      }
+    },
+    "node_modules/@release-it/bumper/node_modules/@iarna/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-td6ZUkz2oS3VeleBcN+m//Q6HlCFCPrnI0FZhrt/h4XqLEdOyYp2u21nd8MdsR+WJy5r9PTDaHTDDfhf4H4l6Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@release-it/bumper/node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@release-it/bumper/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -893,6 +958,13 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/boxen": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
@@ -1042,6 +1114,60 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -1217,6 +1343,36 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -1313,6 +1469,78 @@
         "node": ">= 14"
       }
     },
+    "node_modules/detect-indent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.2.tgz",
+      "integrity": "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dot-prop": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
@@ -1348,6 +1576,46 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -1734,6 +2002,39 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -2231,6 +2532,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -2521,6 +2829,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2727,6 +3048,59 @@
       },
       "engines": {
         "node": ">=14.13.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-is-absolute": {
@@ -3467,6 +3841,43 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/when-exit": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "private": true,
   "scripts": {
     "release": "release-it",
-    "release:dry-run": "release-it --dry-run"
+    "release:dry-run": "release-it --dry-run",
+    "release:prepare": "./scripts/prepare_release.sh",
+    "release:notes": "./scripts/generate_release_notes.sh"
   },
   "devDependencies": {
+    "@release-it/bumper": "^7.0.6",
     "release-it": "^18.0.0"
   }
 }

--- a/scripts/generate_release_notes.sh
+++ b/scripts/generate_release_notes.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-}"
+repo="${2:-${GITHUB_REPOSITORY:-}}"
+target="${3:-${GITHUB_REF_NAME:-main}}"
+output_file="${4:-release-notes.md}"
+
+if [[ -z "$version" ]]; then
+  echo "Usage: $0 <version> [repo] [target] [output_file]" >&2
+  exit 64
+fi
+
+if [[ -z "$repo" ]]; then
+  echo "GitHub repository is required" >&2
+  exit 64
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required" >&2
+  exit 127
+fi
+
+notes="$(
+  gh api \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    "/repos/${repo}/releases/generate-notes" \
+    -f "tag_name=v${version}" \
+    -f "target_commitish=${target}" \
+    --jq '.body'
+)"
+
+summary=""
+if [[ -n "${GITHUB_MODELS_TOKEN:-}" ]]; then
+  prompt=$(
+    cat <<EOF
+Summarize the following GitHub release notes for a Flutter plugin release.
+Return markdown only.
+Keep it factual and concise.
+Write:
+- a title line: ## Summary
+- 3 to 6 bullet points
+- no invented information
+
+Release notes:
+${notes}
+EOF
+  )
+
+  summary="$(
+    gh api \
+      -X POST \
+      -H "Accept: application/vnd.github+json" \
+      "/ai/models/openai/gpt-4.1-mini/inference" \
+      -f "prompt=${prompt}" \
+      --jq '.output[0].content[0].text' 2>/dev/null || true
+  )"
+fi
+
+{
+  if [[ -n "$summary" ]]; then
+    printf '%s\n\n' "$summary"
+  fi
+  printf '%s\n' "$notes"
+} > "$output_file"

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-}"
+
+if [[ -z "$version" ]]; then
+  echo "Usage: $0 <version>" >&2
+  exit 64
+fi
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Version must be in x.y.z format" >&2
+  exit 64
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+
+pubspec="$repo_root/pubspec.yaml"
+podspec="$repo_root/ios/pip.podspec"
+readme="$repo_root/README.md"
+changelog="$repo_root/CHANGELOG.md"
+
+if [[ ! -f "$pubspec" || ! -f "$podspec" ]]; then
+  echo "Expected pubspec.yaml and ios/pip.podspec to exist" >&2
+  exit 1
+fi
+
+perl -0pi -e "s/pip: \^[0-9]+\.[0-9]+\.[0-9]+/pip: ^$version/" "$readme"
+
+if ! grep -Eq "^# $version$|^## $version$" "$changelog"; then
+  tmp_file="$(mktemp)"
+  {
+    echo "# $version"
+    echo
+    echo "- TBD"
+    echo
+    cat "$changelog"
+  } > "$tmp_file"
+  mv "$tmp_file" "$changelog"
+fi

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -8,7 +8,7 @@ case "$mode" in
     dart pub publish --dry-run
     ;;
   publish)
-    dart pub publish
+    dart pub publish --force
     ;;
   *)
     echo "Usage: $0 [dry-run|publish]" >&2

--- a/test/generate_release_notes_test.sh
+++ b/test/generate_release_notes_test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/scripts" "$tmp_dir/bin"
+cp "$repo_root/scripts/generate_release_notes.sh" "$tmp_dir/scripts/generate_release_notes.sh"
+chmod +x "$tmp_dir/scripts/generate_release_notes.sh"
+
+cat > "$tmp_dir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" == *"/releases/generate-notes"* ]]; then
+  printf '%s' "## What's Changed"$'\n\n'"* Add isActive API by @user in #1"
+  exit 0
+fi
+
+if [[ "$*" == *"/ai/models/openai/gpt-4.1-mini/inference"* ]]; then
+  printf '%s' "## Summary"$'\n'"- Added isActive API"$'\n'"- Improved lifecycle handling"
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+EOF
+chmod +x "$tmp_dir/bin/gh"
+
+(
+  cd "$tmp_dir"
+  PATH="$tmp_dir/bin:$PATH" GITHUB_MODELS_TOKEN=dummy ./scripts/generate_release_notes.sh 0.0.4 opentraa/pip main notes.md
+)
+
+grep -Fq '## Summary' "$tmp_dir/notes.md"
+grep -Fq -- '- Added isActive API' "$tmp_dir/notes.md"
+grep -Fq "## What's Changed" "$tmp_dir/notes.md"
+
+cat > "$tmp_dir/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" == *"/releases/generate-notes"* ]]; then
+  printf '%s' "## What's Changed"$'\n\n'"* Add isActive API by @user in #1"
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+EOF
+chmod +x "$tmp_dir/bin/gh"
+
+(
+  cd "$tmp_dir"
+  PATH="$tmp_dir/bin:$PATH" ./scripts/generate_release_notes.sh 0.0.4 opentraa/pip main notes-fallback.md
+)
+
+grep -Fq "## What's Changed" "$tmp_dir/notes-fallback.md"
+if grep -Fq '## Summary' "$tmp_dir/notes-fallback.md"; then
+  echo "fallback notes should not contain AI summary" >&2
+  exit 1
+fi
+
+echo "generate_release_notes.sh tests passed"

--- a/test/prepare_release_test.sh
+++ b/test/prepare_release_test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/ios" "$tmp_dir/scripts"
+cp "$repo_root/pubspec.yaml" "$tmp_dir/pubspec.yaml"
+cp "$repo_root/ios/pip.podspec" "$tmp_dir/ios/pip.podspec"
+cp "$repo_root/README.md" "$tmp_dir/README.md"
+cp "$repo_root/CHANGELOG.md" "$tmp_dir/CHANGELOG.md"
+cp "$repo_root/scripts/prepare_release.sh" "$tmp_dir/scripts/prepare_release.sh"
+chmod +x "$tmp_dir/scripts/prepare_release.sh"
+
+(
+  cd "$tmp_dir"
+  ./scripts/prepare_release.sh 9.9.9
+)
+
+grep -q '^version: 0.0.3$' "$tmp_dir/pubspec.yaml"
+grep -q "s.version          = '0.0.3'" "$tmp_dir/ios/pip.podspec"
+grep -q 'pip: \^9.9.9' "$tmp_dir/README.md"
+grep -q '^# 9.9.9$' "$tmp_dir/CHANGELOG.md"
+grep -q '^- TBD$' "$tmp_dir/CHANGELOG.md"
+
+before_changelog="$(cat "$tmp_dir/CHANGELOG.md")"
+(
+  cd "$tmp_dir"
+  ./scripts/prepare_release.sh 9.9.9
+)
+after_changelog="$(cat "$tmp_dir/CHANGELOG.md")"
+
+if [[ "$before_changelog" != "$after_changelog" ]]; then
+  echo "prepare_release.sh should not duplicate changelog entries" >&2
+  exit 1
+fi
+
+if (
+  cd "$tmp_dir"
+  ./scripts/prepare_release.sh invalid >/dev/null 2>&1
+); then
+  echo "expected invalid version to fail" >&2
+  exit 1
+fi
+
+echo "prepare_release.sh tests passed"

--- a/test/pubignore_test.sh
+++ b/test/pubignore_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pubignore="$repo_root/.pubignore"
+
+grep -Fq 'node_modules/' "$pubignore"
+grep -Fq 'package.json' "$pubignore"
+grep -Fq 'package-lock.json' "$pubignore"
+grep -Fq '.release-it.json' "$pubignore"
+grep -Fq '.release-notes.md' "$pubignore"
+
+echo ".pubignore tests passed"

--- a/test/publish_script_test.sh
+++ b/test/publish_script_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! grep -Fq 'dart pub publish --force' "$repo_root/scripts/publish.sh"; then
+  echo "publish.sh must use non-interactive pub publish --force" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'dart pub publish --dry-run' "$repo_root/scripts/publish.sh"; then
+  echo "publish.sh must keep dry-run mode" >&2
+  exit 1
+fi
+
+echo "publish.sh tests passed"

--- a/test/release_it_config_test.sh
+++ b/test/release_it_config_test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+grep -Fq '"after:bump": "./scripts/prepare_release.sh ${version}"' "$repo_root/.release-it.json"
+grep -Fq '"before:git:release": "RELEASE_VERSION=${version} ./scripts/check_release_ready.sh"' "$repo_root/.release-it.json"
+grep -Fq '"@release-it/bumper"' "$repo_root/.release-it.json"
+grep -Fq '"file": "pubspec.yaml"' "$repo_root/.release-it.json"
+grep -Fq '"file": "ios/pip.podspec"' "$repo_root/.release-it.json"
+grep -Fq '"npm": false' "$repo_root/.release-it.json"
+grep -Fq '"requireUpstream": false' "$repo_root/.release-it.json"
+grep -Fq '"releaseNotes": "cat .release-notes.md"' "$repo_root/.release-it.json"
+
+echo "release-it config tests passed"

--- a/test/release_workflow_test.sh
+++ b/test/release_workflow_test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow="$repo_root/.github/workflows/release.yml"
+
+grep -Fq 'models: read' "$workflow"
+grep -Fq 'Generate release notes' "$workflow"
+grep -Fq './scripts/generate_release_notes.sh ${{ inputs.version }} ${{ github.repository }} ${{ github.ref_name }} .release-notes.md' "$workflow"
+
+echo "release workflow tests passed"

--- a/test/workflow_publish_test.sh
+++ b/test/workflow_publish_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow="$repo_root/.github/workflows/publish.yml"
+
+grep -Fq "on:" "$workflow"
+grep -Fq "  push:" "$workflow"
+grep -Fq "      - 'v*.*.*'" "$workflow"
+grep -Fq "    environment: pub.dev" "$workflow"
+grep -Fq "uses: dart-lang/setup-dart@v1" "$workflow"
+
+echo "publish workflow tests passed"


### PR DESCRIPTION
## Summary

- automate release version bumping with `release-it`
- generate GitHub release notes before release creation
- optionally prepend a GitHub Models summary to the release body
- publish tagged releases to `pub.dev` through a tag-triggered workflow
- add regression tests for release scripts and workflow configuration

## Flow

1. Run the `Release` workflow with a target version like `0.0.4`
2. The workflow generates `.release-notes.md`
3. `release-it` bumps release metadata, commits, tags, pushes, and creates the GitHub Release
4. The pushed tag triggers the `Publish` workflow
5. The `Publish` workflow releases the package to `pub.dev`

## Validation

- `bash test/prepare_release_test.sh`
- `bash test/check_release_ready_test.sh`
- `bash test/publish_script_test.sh`
- `bash test/release_it_config_test.sh`
- `bash test/pubignore_test.sh`
- `bash test/workflow_publish_test.sh`
- `bash test/release_workflow_test.sh`
- `bash test/generate_release_notes_test.sh`
- isolated `release-it --dry-run --ci 0.0.4`

## Notes

- `Release` requires GitHub Actions `models: read` permission for the optional AI summary
- if GitHub Models is unavailable, the workflow falls back to GitHub generated release notes only
- `Publish` requires `pub.dev` automated publishing via GitHub Actions OIDC
