### PR TITLE
[codex] remove model API from release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Generate release notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_MODELS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: ./scripts/generate_release_notes.sh ${{ inputs.version }} ${{ github.repository }} ${{ github.ref_name }} .release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
     permissions:
       actions: write
       contents: write
-      models: read
 
     steps:
       - name: Checkout

--- a/scripts/generate_release_notes.sh
+++ b/scripts/generate_release_notes.sh
@@ -32,31 +32,6 @@ notes="$(
 )"
 
 summary=""
-if [[ -n "${GITHUB_MODELS_TOKEN:-}" ]]; then
-  prompt=$(
-    cat <<EOF
-Summarize the following GitHub release notes for a Flutter plugin release.
-Return markdown only.
-Keep it factual and concise.
-Write:
-- a title line: ## Summary
-- 3 to 6 bullet points
-- no invented information
-
-Release notes:
-${notes}
-EOF
-  )
-
-  summary="$(
-    gh api \
-      -X POST \
-      -H "Accept: application/vnd.github+json" \
-      "/ai/models/openai/gpt-4.1-mini/inference" \
-      -f "prompt=${prompt}" \
-      --jq '.output[0].content[0].text' 2>/dev/null || true
-  )"
-fi
 
 {
   if [[ -n "$summary" ]]; then

--- a/test/generate_release_notes_test.sh
+++ b/test/generate_release_notes_test.sh
@@ -18,11 +18,6 @@ if [[ "$*" == *"/releases/generate-notes"* ]]; then
   exit 0
 fi
 
-if [[ "$*" == *"/ai/models/openai/gpt-4.1-mini/inference"* ]]; then
-  printf '%s' "## Summary"$'\n'"- Added isActive API"$'\n'"- Improved lifecycle handling"
-  exit 0
-fi
-
 echo "unexpected gh invocation: $*" >&2
 exit 1
 EOF
@@ -33,9 +28,11 @@ chmod +x "$tmp_dir/bin/gh"
   PATH="$tmp_dir/bin:$PATH" GITHUB_MODELS_TOKEN=dummy ./scripts/generate_release_notes.sh 0.0.4 opentraa/pip main notes.md
 )
 
-grep -Fq '## Summary' "$tmp_dir/notes.md"
-grep -Fq -- '- Added isActive API' "$tmp_dir/notes.md"
 grep -Fq "## What's Changed" "$tmp_dir/notes.md"
+if grep -Fq '## Summary' "$tmp_dir/notes.md"; then
+  echo "notes should not contain AI-generated summary content" >&2
+  exit 1
+fi
 
 cat > "$tmp_dir/bin/gh" <<'EOF'
 #!/usr/bin/env bash
@@ -53,12 +50,16 @@ chmod +x "$tmp_dir/bin/gh"
 
 (
   cd "$tmp_dir"
-  PATH="$tmp_dir/bin:$PATH" ./scripts/generate_release_notes.sh 0.0.4 opentraa/pip main notes-fallback.md
+  PATH="$tmp_dir/bin:$PATH" GITHUB_MODELS_TOKEN=dummy ./scripts/generate_release_notes.sh 0.0.4 opentraa/pip main notes-fallback.md
 )
 
 grep -Fq "## What's Changed" "$tmp_dir/notes-fallback.md"
 if grep -Fq '## Summary' "$tmp_dir/notes-fallback.md"; then
   echo "fallback notes should not contain AI summary" >&2
+  exit 1
+fi
+if grep -Fq '"message": "Not Found"' "$tmp_dir/notes-fallback.md"; then
+  echo "fallback notes should not contain GitHub API error payloads" >&2
   exit 1
 fi
 

--- a/test/prepare_release_test.sh
+++ b/test/prepare_release_test.sh
@@ -13,6 +13,9 @@ cp "$repo_root/CHANGELOG.md" "$tmp_dir/CHANGELOG.md"
 cp "$repo_root/scripts/prepare_release.sh" "$tmp_dir/scripts/prepare_release.sh"
 chmod +x "$tmp_dir/scripts/prepare_release.sh"
 
+original_pubspec="$(cat "$tmp_dir/pubspec.yaml")"
+original_podspec="$(cat "$tmp_dir/ios/pip.podspec")"
+
 cat > "$tmp_dir/.release-notes.md" <<'EOF'
 ## Summary
 
@@ -28,8 +31,15 @@ EOF
   ./scripts/prepare_release.sh 9.9.9
 )
 
-grep -q '^version: 0.0.3$' "$tmp_dir/pubspec.yaml"
-grep -q "s.version          = '0.0.3'" "$tmp_dir/ios/pip.podspec"
+if [[ "$(cat "$tmp_dir/pubspec.yaml")" != "$original_pubspec" ]]; then
+  echo "prepare_release.sh must not modify pubspec.yaml" >&2
+  exit 1
+fi
+
+if [[ "$(cat "$tmp_dir/ios/pip.podspec")" != "$original_podspec" ]]; then
+  echo "prepare_release.sh must not modify ios/pip.podspec" >&2
+  exit 1
+fi
 grep -q 'pip: \^9.9.9' "$tmp_dir/README.md"
 grep -q '^# 9.9.9$' "$tmp_dir/CHANGELOG.md"
 grep -q '^## Summary$' "$tmp_dir/CHANGELOG.md"

--- a/test/release_workflow_test.sh
+++ b/test/release_workflow_test.sh
@@ -5,10 +5,13 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 workflow="$repo_root/.github/workflows/release.yml"
 
 grep -Fq 'actions: write' "$workflow"
-grep -Fq 'models: read' "$workflow"
 grep -Fq 'Generate release notes' "$workflow"
 grep -Fq './scripts/generate_release_notes.sh ${{ inputs.version }} ${{ github.repository }} ${{ github.ref_name }} .release-notes.md' "$workflow"
 grep -Fq 'npm run release -- --ci --verbose ${{ inputs.version }}' "$workflow"
 grep -Fq 'gh workflow run Publish --ref v${{ inputs.version }}' "$workflow"
+if grep -Fq 'GITHUB_MODELS_TOKEN' "$workflow"; then
+  echo "release workflow should not set a GitHub Models token" >&2
+  exit 1
+fi
 
 echo "release workflow tests passed"


### PR DESCRIPTION
## Summary

- remove the GitHub Models summary path from release note generation
- keep release notes sourced only from GitHub generated release notes
- harden release note tests so API error payloads cannot leak into changelog output
- update the release workflow assertion to ensure no Models token is passed

## Validation

- \check_release_ready.sh tests passed
- \prepare_release.sh tests passed
- \publish.sh tests passed
- \release-it config tests passed
- \.pubignore tests passed
- \publish workflow tests passed
- \release workflow tests passed
- \generate_release_notes.sh tests passed