### PR TITLE
[codex] split GitHub release and pub.dev tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
         type: string
   push:
     tags:
-      - '*.*.*'
+      - '[0-9]*.[0-9]*.[0-9]*'
 
 jobs:
   dry-run:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing release tag to publish, for example v0.0.4
+        description: Existing pub.dev release tag to publish, for example 0.0.4
         required: true
         type: string
   push:
     tags:
-      - 'v*.*.*'
+      - '*.*.*'
 
 jobs:
   dry-run:
@@ -21,8 +21,8 @@ jobs:
         env:
           TAG: ${{ inputs.tag }}
         run: |
-          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid tag format: '${TAG}'. Tag must match pattern v0.0.0 (e.g., v0.0.4)" >&2
+          if [[ ! "${TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid tag format: '${TAG}'. Tag must match pattern 0.0.0 (e.g., 0.0.4)" >&2
             exit 1
           fi
 
@@ -58,8 +58,8 @@ jobs:
         env:
           TAG: ${{ github.ref_name }}
         run: |
-          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid tag format: '${TAG}'. Tag must match pattern v0.0.0 (e.g., v0.0.4)" >&2
+          if [[ ! "${TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid tag format: '${TAG}'. Tag must match pattern 0.0.0 (e.g., 0.0.4)" >&2
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ Maintainers publish new versions through GitHub Actions:
 
 - Run the `Release` workflow with the target version number.
 - The workflow generates GitHub release notes, optionally prepends a GitHub
-  Models summary, updates release metadata, and creates the GitHub Release.
-- The resulting tag automatically triggers the `Publish` workflow for `pub.dev`.
+  Models summary, updates release metadata, and creates the GitHub Release
+  using a `vX.Y.Z` tag.
+- After reviewing the GitHub release, manually create and push a matching
+  `X.Y.Z` tag to trigger the `Publish` workflow for `pub.dev`.
 
 The `Publish` workflow depends on Dart automated publishing for GitHub Actions.

--- a/test/release_process_docs_test.sh
+++ b/test/release_process_docs_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readme="$repo_root/README.md"
+
+grep -Fq 'using a `vX.Y.Z` tag.' "$readme"
+grep -Fq 'manually create and push a matching' "$readme"
+grep -Fq '`X.Y.Z` tag to trigger the `Publish` workflow for `pub.dev`.' "$readme"
+
+if grep -Fq 'The resulting tag automatically triggers the `Publish` workflow for `pub.dev`.' "$readme"; then
+  echo "README should not describe GitHub release tags as automatically publishing to pub.dev" >&2
+  exit 1
+fi
+
+echo "release process docs tests passed"

--- a/test/workflow_publish_test.sh
+++ b/test/workflow_publish_test.sh
@@ -9,7 +9,7 @@ grep -Fq "  workflow_dispatch:" "$workflow"
 grep -Fq "      tag:" "$workflow"
 grep -Fq "        description: Existing pub.dev release tag to publish, for example 0.0.4" "$workflow"
 grep -Fq "  push:" "$workflow"
-grep -Fq "      - '*.*.*'" "$workflow"
+grep -Fq "      - '[0-9]*.[0-9]*.[0-9]*'" "$workflow"
 
 grep -Fq "  dry-run:" "$workflow"
 grep -Fq "    if: github.event_name == 'workflow_dispatch'" "$workflow"

--- a/test/workflow_publish_test.sh
+++ b/test/workflow_publish_test.sh
@@ -7,9 +7,9 @@ workflow="$repo_root/.github/workflows/publish.yml"
 grep -Fq "on:" "$workflow"
 grep -Fq "  workflow_dispatch:" "$workflow"
 grep -Fq "      tag:" "$workflow"
-grep -Fq "        description: Existing release tag to publish, for example v0.0.4" "$workflow"
+grep -Fq "        description: Existing pub.dev release tag to publish, for example 0.0.4" "$workflow"
 grep -Fq "  push:" "$workflow"
-grep -Fq "      - 'v*.*.*'" "$workflow"
+grep -Fq "      - '*.*.*'" "$workflow"
 
 grep -Fq "  dry-run:" "$workflow"
 grep -Fq "    if: github.event_name == 'workflow_dispatch'" "$workflow"
@@ -17,20 +17,22 @@ grep -Fq "uses: dart-lang/setup-dart@v1" "$workflow"
 grep -Fq "run: ./scripts/check.sh" "$workflow"
 grep -Fq "run: ./scripts/check_release_ready.sh" "$workflow"
 grep -Fq "run: ./scripts/publish.sh dry-run" "$workflow"
+grep -Fq "Tag must match pattern 0.0.0 (e.g., 0.0.4)" "$workflow"
 
 grep -Fq "  prepublish:" "$workflow"
 grep -Fq "    if: github.event_name == 'push'" "$workflow"
 grep -Fq "run: ./scripts/check.sh" "$workflow"
 grep -Fq "run: ./scripts/check_release_ready.sh" "$workflow"
+grep -Fq "TAG: \${{ github.ref_name }}" "$workflow"
 
 grep -Fq "  publish:" "$workflow"
 grep -Fq "    if: github.event_name == 'push'" "$workflow"
 grep -Fq "    needs: prepublish" "$workflow"
-grep -Fq "uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1" "$workflow"
+grep -Fq "run: ./scripts/publish.sh publish" "$workflow"
 grep -Fq "      contents: read" "$workflow"
 grep -Fq "      id-token: write" "$workflow"
-if grep -Fq "./scripts/publish.sh publish" "$workflow"; then
-  echo "publish workflow should use the Dart reusable publish workflow for real publishing" >&2
+if grep -Fq "v0.0.4" "$workflow"; then
+  echo "publish workflow should not document v-prefixed tags for pub.dev publishing" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- switch the Publish workflow to pure numeric pub.dev tags
- document the dual-tag release flow for GitHub releases vs pub.dev publishing
- update workflow tests and add a README guard test for the new release semantics

## Why
The repository needs two separate tag systems:
- `vX.Y.Z` tags created by the Release workflow for GitHub Releases
- `X.Y.Z` tags pushed manually by maintainers to trigger pub.dev trusted publishing

This avoids relying on workflow-generated tags to trigger downstream publishing while keeping `release-it` for version/changelog automation.

## Validation
- `bash test/check_release_ready_test.sh`
- `bash test/generate_release_notes_test.sh`
- `bash test/prepare_release_test.sh`
- `bash test/release_it_config_test.sh`
- `bash test/release_workflow_test.sh`
- `bash test/workflow_publish_test.sh`
- `bash test/release_process_docs_test.sh`
